### PR TITLE
Add Mux AI documentation assistant (RAG over docs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,8 +98,9 @@ jobs:
         run: ./scripts/integration-checks.sh
   sonarqube:
     name: SonarQube
-    needs: detect-changes
-    if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
+    # Runs on every push and pull request (no path gating): SonarQube analyzes
+    # the whole project, including the TypeScript/JS under mux-website, workers/,
+    # and tools/, so it must not be skipped just because no Rust files changed.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ test_scripts/error_cases/*.mux
 !test_scripts/error_cases/*.mux
 test_scripts/error_cases/*
 
+# JavaScript / Node (mux-website, workers/, tools/). Global rule so any future
+# JS subdir is covered automatically rather than relying on a per-dir .gitignore.
+**/node_modules
+
 .scannerwork/*
 ci-artifacts/
 .docker-cache/

--- a/docs/error-corpus/lexer.json
+++ b/docs/error-corpus/lexer.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "lexer_unterminated_string",
+    "source": "\"hello",
+    "error": "Unterminated string",
+    "help": "Make sure to close the string with a matching quote",
+    "category": "lexer",
+    "relevant_docs": ["/docs/reference/lexical-structure/", "/docs/language-guide/types/"]
+  },
+  {
+    "id": "lexer_invalid_char",
+    "source": "§",
+    "error": "Unexpected character: '§'",
+    "help": "This character is not recognized as valid Mux syntax. Check for accidental special characters or encoding issues.",
+    "category": "lexer",
+    "relevant_docs": []
+  },
+  {
+    "id": "lexer_unknown_escape",
+    "source": "auto s = \"hi\\z\"",
+    "error": "Unknown escape sequence: \\z",
+    "help": "Valid escape sequences: \\n, \\t, \\r, \\0, \\\\, \\', \\\"",
+    "category": "lexer",
+    "relevant_docs": ["/docs/language-guide/types/"]
+  },
+  {
+    "id": "lexer_unterminated_comment",
+    "source": "/* unclosed comment",
+    "error": "Unterminated block comment",
+    "help": "Make sure to close the block comment with '*/'",
+    "category": "lexer",
+    "relevant_docs": []
+  }
+]

--- a/docs/error-corpus/parser.json
+++ b/docs/error-corpus/parser.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "parser_break_outside_loop",
+    "source": "break",
+    "error": "Cannot use 'break' outside of a loop",
+    "help": "'break' can only be used inside a 'for' or 'while' loop",
+    "category": "parser",
+    "relevant_docs": ["/docs/language-guide/control-flow/"]
+  },
+  {
+    "id": "parser_continue_outside_loop",
+    "source": "continue",
+    "error": "Cannot use 'continue' outside of a loop",
+    "help": "'continue' can only be used inside a 'for' or 'while' loop",
+    "category": "parser",
+    "relevant_docs": ["/docs/language-guide/control-flow/"]
+  },
+  {
+    "id": "parser_return_outside_func",
+    "source": "return 42",
+    "error": "Cannot use 'return' outside of a function",
+    "help": null,
+    "category": "parser",
+    "relevant_docs": ["/docs/language-guide/functions/", "/docs/reference/statements/"]
+  },
+  {
+    "id": "parser_missing_return_type",
+    "source": "func bar() returns",
+    "error": "Expected type",
+    "help": null,
+    "category": "parser",
+    "relevant_docs": ["/docs/language-guide/functions/"]
+  },
+  {
+    "id": "parser_missing_if_expr",
+    "source": "if { print(\"hi\") }",
+    "error": "Expected expression",
+    "help": null,
+    "category": "parser",
+    "relevant_docs": [
+      "/docs/language-guide/control-flow/",
+      "/docs/reference/expressions/",
+      "/docs/reference/statements/"
+    ]
+  }
+]

--- a/docs/error-corpus/semantic.json
+++ b/docs/error-corpus/semantic.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "semantic_type_mismatch",
+    "source": "int n = \"hello\"",
+    "error": "Type mismatch: expected int, got string",
+    "help": null,
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/types/", "/docs/language-guide/variables/"]
+  },
+  {
+    "id": "semantic_wrong_return",
+    "source": "func baz() returns int { return \"str\" }",
+    "error": "Type mismatch: expected int, got string",
+    "help": null,
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/functions/", "/docs/language-guide/types/"]
+  },
+  {
+    "id": "semantic_undefined_var",
+    "source": "print(x)",
+    "error": "Undefined variable 'x'",
+    "help": null,
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/variables/"]
+  },
+  {
+    "id": "semantic_duplicate_var",
+    "source": "auto x = 5\nauto x = 6",
+    "error": "Duplicate declaration of 'x'",
+    "help": null,
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/variables/"]
+  },
+  {
+    "id": "semantic_match_missing_wildcard",
+    "source": "match x { 1 { print(\"one\") } 2 { print(\"two\") } }",
+    "error": "Non-exhaustive match on type 'int'",
+    "help": "Add a wildcard '_' pattern as the last match arm to handle all remaining cases",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/control-flow/"]
+  },
+  {
+    "id": "semantic_wrong_interface",
+    "source": "interface I { func foo() returns void }\nclass C is I {}",
+    "error": "Class 'C' does not implement method 'foo' required by interface 'I'",
+    "help": "Add a method 'foo' to class 'C' with the signature required by interface 'I'",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/classes/"]
+  },
+  {
+    "id": "semantic_missing_return_if",
+    "source": "func get_value(int x) returns int { if x > 0 { return x * 2 } }",
+    "error": "Function must return a value of type 'int' on all code paths",
+    "help": "Add a return statement at the end of every branch (if/else, match, etc.)",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/functions/", "/docs/language-guide/control-flow/"]
+  },
+  {
+    "id": "semantic_assign_const",
+    "source": "const x = 5\nx = 10",
+    "error": "Cannot assign to constant 'x'",
+    "help": null,
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/variables/"]
+  },
+  {
+    "id": "semantic_undefined_type_list_new",
+    "source": "auto empty_list = list.new()",
+    "error": "Undefined variable 'list'",
+    "help": "List has no '.new()' constructor. Use '[]' for an empty list or '[1, 2, 3]' for elements.",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/collections/"]
+  },
+  {
+    "id": "semantic_wrong_arg_count",
+    "source": "func add(int a, int b) returns int { return a + b }\nadd(1)",
+    "error": "Wrong number of arguments: expected 2, got 1",
+    "help": null,
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/functions/"]
+  }
+]

--- a/mux-website/docs/language-guide/functions.md
+++ b/mux-website/docs/language-guide/functions.md
@@ -222,6 +222,25 @@ auto result = myString.to_int().to_string()
 auto doubled = square(add(2, 3))
 ```
 
+### Argument Count
+
+A call must pass exactly as many arguments as the function declares (after
+accounting for any defaults). Passing too few or too many arguments is a
+compile-time error, not a runtime one.
+
+```mux title="argument_count.mux"
+func add(int a, int b) returns int {
+    return a + b
+}
+
+auto ok = add(1, 2)   // correct: two arguments
+auto bad = add(1)     // error: Wrong number of arguments: expected 2, got 1
+```
+
+To call a function with fewer explicit arguments, give the trailing parameters
+default values (see Default Parameters above); parameters without defaults are
+always required.
+
 ### Calling `main()` Explicitly
 
 Mux allows explicit calls to `main()` from user code.

--- a/mux-website/docusaurus.config.ts
+++ b/mux-website/docusaurus.config.ts
@@ -188,6 +188,7 @@ const config: Config = {
   customFields: {
     version: siteVersion,
     apiUrl: process.env.MUX_API_URL ?? 'https://mux-lang-api.fly.dev',
+    aiApiUrl: process.env.MUX_AI_API_URL ?? 'https://mux-ai.corniedj.workers.dev',
   },
 };
 

--- a/mux-website/docusaurus.config.ts
+++ b/mux-website/docusaurus.config.ts
@@ -22,7 +22,7 @@ function parseFrontMatter(fileContent: string): {
   content: string;
 } {
   // Limit searchable content to prevent ReDoS on malformed front matter
-  const frontMatterMatch = /^---\s*\r?\n([\s\S]*?)\r?\n---\s*(?:\r?\n|$)/.exec(
+  const frontMatterMatch = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/.exec(
     fileContent.slice(0, 10240),
   );
 

--- a/mux-website/package-lock.json
+++ b/mux-website/package-lock.json
@@ -25,6 +25,7 @@
         "prism-react-renderer": "^2.3.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
         "shiki": "^4.0.2"
       },
@@ -12329,6 +12330,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -18652,6 +18663,33 @@
       "peerDependencies": {
         "react-loadable": "*",
         "webpack": ">=4.41.1 || 5.x"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
       }
     },
     "node_modules/react-router": {

--- a/mux-website/package.json
+++ b/mux-website/package.json
@@ -33,6 +33,7 @@
     "prism-react-renderer": "^2.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
     "shiki": "^4.0.2"
   },

--- a/mux-website/src/api/chat.ts
+++ b/mux-website/src/api/chat.ts
@@ -1,0 +1,39 @@
+import type { ChatMessage, ChatResponse } from '../lib/chatTypes';
+
+async function readChatResponse(res: Response): Promise<ChatResponse> {
+  // Read the body exactly once, then try to parse it as JSON. Reading the
+  // stream twice (res.json() then res.text()) throws "body already read".
+  const text = (await res.text()).trim();
+
+  if (text) {
+    try {
+      return JSON.parse(text) as ChatResponse;
+    } catch {
+      // Not JSON; fall through to text/status handling below.
+    }
+  }
+
+  if (res.status === 429) {
+    return { error: 'Too many requests. Please wait and try again.', errorCode: 'RATE_LIMIT' };
+  }
+
+  if (text) {
+    return { error: text };
+  }
+
+  return { error: `Request failed (${res.status})` };
+}
+
+export async function sendChat(apiUrl: string, messages: ChatMessage[]): Promise<ChatResponse> {
+  const res = await fetch(`${apiUrl}/api/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ messages }),
+  });
+
+  const data = await readChatResponse(res);
+  if (res.ok && !data.message && !data.error) {
+    return { error: 'Server returned an unexpected response' };
+  }
+  return data;
+}

--- a/mux-website/src/components/Chat/ChatButton.tsx
+++ b/mux-website/src/components/Chat/ChatButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface ChatButtonProps {
+  onClick: () => void;
+}
+
+const ChatButton: React.FC<ChatButtonProps> = ({ onClick }) => {
+  return (
+    <button
+      type="button"
+      className="mux-chat-button"
+      onClick={onClick}
+      aria-label="Open Mux AI assistant"
+    >
+      Ask Mux AI
+    </button>
+  );
+};
+
+export default ChatButton;

--- a/mux-website/src/components/Chat/ChatDrawer.tsx
+++ b/mux-website/src/components/Chat/ChatDrawer.tsx
@@ -28,7 +28,7 @@ const ChatDrawer: React.FC<ChatDrawerProps> = ({ open, onClose }) => {
   }
 
   return (
-    <div className="mux-chat-drawer" role="dialog" aria-modal="true" aria-label="Mux AI assistant">
+    <dialog className="mux-chat-drawer" open aria-label="Mux AI assistant">
       <div className="mux-chat-drawer-header">
         <span className="mux-chat-drawer-title">Mux AI</span>
         <div className="mux-chat-drawer-header-actions">
@@ -57,8 +57,8 @@ const ChatDrawer: React.FC<ChatDrawerProps> = ({ open, onClose }) => {
             Ask a question about Mux and I will answer using the official docs.
           </p>
         )}
-        {messages.map((message, index) => (
-          <ChatMessage key={index} message={message} />
+        {messages.map((message) => (
+          <ChatMessage key={message.id} message={message} />
         ))}
         {loading && <ChatTypingIndicator />}
         {error && <p className="mux-chat-drawer-error">{error}</p>}
@@ -70,7 +70,7 @@ const ChatDrawer: React.FC<ChatDrawerProps> = ({ open, onClose }) => {
       </div>
 
       <ChatInput onSend={sendMessage} disabled={loading || sessionLimitReached} />
-    </div>
+    </dialog>
   );
 };
 

--- a/mux-website/src/components/Chat/ChatDrawer.tsx
+++ b/mux-website/src/components/Chat/ChatDrawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ChatMessage from './ChatMessage';
 import ChatInput from './ChatInput';
 import ChatTypingIndicator from './ChatTypingIndicator';
@@ -12,13 +12,23 @@ interface ChatDrawerProps {
 const ChatDrawer: React.FC<ChatDrawerProps> = ({ open, onClose }) => {
   const { messages, loading, error, sessionLimitReached, sendMessage, clearConversation } =
     useChat();
+  const messagesRef = useRef<HTMLDivElement>(null);
+
+  // Keep the newest message (and the typing indicator) in view as the
+  // conversation grows, instead of leaving it below the visible area.
+  useEffect(() => {
+    const el = messagesRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [messages, loading]);
 
   if (!open) {
     return null;
   }
 
   return (
-    <div className="mux-chat-drawer" role="dialog" aria-label="Mux AI assistant">
+    <div className="mux-chat-drawer" role="dialog" aria-modal="true" aria-label="Mux AI assistant">
       <div className="mux-chat-drawer-header">
         <span className="mux-chat-drawer-title">Mux AI</span>
         <div className="mux-chat-drawer-header-actions">
@@ -41,7 +51,7 @@ const ChatDrawer: React.FC<ChatDrawerProps> = ({ open, onClose }) => {
         </div>
       </div>
 
-      <div className="mux-chat-drawer-messages">
+      <div className="mux-chat-drawer-messages" ref={messagesRef}>
         {messages.length === 0 && !loading && (
           <p className="mux-chat-drawer-empty">
             Ask a question about Mux and I will answer using the official docs.

--- a/mux-website/src/components/Chat/ChatDrawer.tsx
+++ b/mux-website/src/components/Chat/ChatDrawer.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import ChatMessage from './ChatMessage';
+import ChatInput from './ChatInput';
+import ChatTypingIndicator from './ChatTypingIndicator';
+import useChat from '../../hooks/useChat';
+
+interface ChatDrawerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const ChatDrawer: React.FC<ChatDrawerProps> = ({ open, onClose }) => {
+  const { messages, loading, error, sessionLimitReached, sendMessage, clearConversation } =
+    useChat();
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="mux-chat-drawer" role="dialog" aria-label="Mux AI assistant">
+      <div className="mux-chat-drawer-header">
+        <span className="mux-chat-drawer-title">Mux AI</span>
+        <div className="mux-chat-drawer-header-actions">
+          <button
+            type="button"
+            className="mux-chat-drawer-clear"
+            onClick={clearConversation}
+            disabled={messages.length === 0}
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            className="mux-chat-drawer-close"
+            onClick={onClose}
+            aria-label="Close Mux AI assistant"
+          >
+            &times;
+          </button>
+        </div>
+      </div>
+
+      <div className="mux-chat-drawer-messages">
+        {messages.length === 0 && !loading && (
+          <p className="mux-chat-drawer-empty">
+            Ask a question about Mux and I will answer using the official docs.
+          </p>
+        )}
+        {messages.map((message, index) => (
+          <ChatMessage key={index} message={message} />
+        ))}
+        {loading && <ChatTypingIndicator />}
+        {error && <p className="mux-chat-drawer-error">{error}</p>}
+        {sessionLimitReached && (
+          <p className="mux-chat-drawer-limit">
+            You have reached the session message limit. Refresh the page to start a new session.
+          </p>
+        )}
+      </div>
+
+      <ChatInput onSend={sendMessage} disabled={loading || sessionLimitReached} />
+    </div>
+  );
+};
+
+export default ChatDrawer;

--- a/mux-website/src/components/Chat/ChatInput.tsx
+++ b/mux-website/src/components/Chat/ChatInput.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+interface ChatInputProps {
+  onSend: (content: string) => void;
+  disabled?: boolean;
+}
+
+const ChatInput: React.FC<ChatInputProps> = ({ onSend, disabled }) => {
+  const [value, setValue] = useState('');
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!value.trim() || disabled) {
+      return;
+    }
+    onSend(value);
+    setValue('');
+  };
+
+  return (
+    <form className="mux-chat-input-form" onSubmit={handleSubmit}>
+      <input
+        type="text"
+        className="mux-chat-input"
+        placeholder="Ask about Mux..."
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        disabled={disabled}
+        aria-label="Chat message"
+        // Mirrors the Worker's MAX_CONTENT_CHARS (workers/mux-ai/src/index.ts)
+        // so the user gets instant feedback instead of a round-trip 400.
+        maxLength={2000}
+      />
+      <button
+        type="submit"
+        className="mux-chat-send-button"
+        disabled={disabled || !value.trim()}
+      >
+        Send
+      </button>
+    </form>
+  );
+};
+
+export default ChatInput;

--- a/mux-website/src/components/Chat/ChatMessage.tsx
+++ b/mux-website/src/components/Chat/ChatMessage.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import type { Components } from 'react-markdown';
+import CodeBlock from '@theme/CodeBlock';
+import type { ChatMessage as ChatMessageType } from '../../lib/chatTypes';
+
+interface ChatMessageProps {
+  message: ChatMessageType;
+}
+
+const SITE_BASE = 'https://mux-lang.dev';
+
+// Render assistant markdown through Docusaurus' own CodeBlock so fenced code is
+// highlighted with the same theme as the rest of the site. react-markdown wraps
+// block code in <pre>; we make <pre> a passthrough so CodeBlock provides its own
+// instead of being nested inside a second <pre>.
+const markdownComponents: Components = {
+  pre: ({ children }) => <>{children}</>,
+  code({ className, children }) {
+    const match = /language-(\w+)/.exec(className ?? '');
+    if (match) {
+      return (
+        <CodeBlock language={match[1]}>{String(children).replace(/\n$/, '')}</CodeBlock>
+      );
+    }
+    return <code className="mux-chat-inline-code">{children}</code>;
+  },
+  a: ({ href, children }) => (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ),
+};
+
+const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
+  const isAssistant = message.role === 'assistant';
+  const hasSources = isAssistant && message.sources && message.sources.length > 0;
+
+  return (
+    <div className={`mux-chat-message mux-chat-message-${message.role}`}>
+      <div className="mux-chat-message-content">
+        <div className="mux-chat-message-bubble">
+          {isAssistant ? (
+            <ReactMarkdown components={markdownComponents}>{message.content}</ReactMarkdown>
+          ) : (
+            message.content
+          )}
+        </div>
+        {hasSources && (
+          <div className="mux-chat-message-sources">
+            <span className="mux-chat-message-sources-label">Sources</span>
+            <ul className="mux-chat-message-sources-list">
+              {message.sources!.map((source) => (
+                <li key={source.path}>
+                  <a
+                    href={`${SITE_BASE}${source.path}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mux-chat-message-sources-link"
+                  >
+                    {source.title}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ChatMessage;

--- a/mux-website/src/components/Chat/ChatTypingIndicator.tsx
+++ b/mux-website/src/components/Chat/ChatTypingIndicator.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const ChatTypingIndicator: React.FC = () => {
+  return (
+    <div className="mux-chat-typing" aria-label="Mux AI is typing">
+      <span className="mux-chat-typing-dot" />
+      <span className="mux-chat-typing-dot" />
+      <span className="mux-chat-typing-dot" />
+    </div>
+  );
+};
+
+export default ChatTypingIndicator;

--- a/mux-website/src/components/Chat/index.tsx
+++ b/mux-website/src/components/Chat/index.tsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import ChatButton from './ChatButton';
+import ChatDrawer from './ChatDrawer';
+
+const Chat: React.FC = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      {!open && <ChatButton onClick={() => setOpen(true)} />}
+      <ChatDrawer open={open} onClose={() => setOpen(false)} />
+    </>
+  );
+};
+
+export default Chat;

--- a/mux-website/src/css/custom.css
+++ b/mux-website/src/css/custom.css
@@ -1101,7 +1101,7 @@ hr {
 .playground-output-text {
   margin: 0;
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
   font-family: var(--ifm-font-family-monospace);
   font-size: 0.86rem;
   line-height: 1.55;
@@ -1329,6 +1329,10 @@ hr {
   max-height: 70vh;
   display: flex;
   flex-direction: column;
+  /* Reset native <dialog> user-agent defaults (padding, margin) so the panel
+     layout is unaffected by using a semantic dialog element. */
+  margin: 0;
+  padding: 0;
   border: 1px solid var(--terminal-border);
   border-radius: 12px;
   background-color: var(--ifm-background-surface-color);

--- a/mux-website/src/css/custom.css
+++ b/mux-website/src/css/custom.css
@@ -1297,3 +1297,311 @@ hr {
     justify-content: center;
   }
 }
+
+/* Mux AI Chat styles */
+.mux-chat-button {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 200;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 24px;
+  background-color: var(--ifm-color-primary);
+  color: white;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  transition: background-color 0.15s ease;
+}
+
+.mux-chat-button:hover {
+  background-color: var(--ifm-color-primary-dark);
+}
+
+.mux-chat-drawer {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 200;
+  width: 360px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--terminal-border);
+  border-radius: 12px;
+  background-color: var(--ifm-background-surface-color);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.mux-chat-drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: linear-gradient(to bottom, var(--terminal-header-top) 0%, var(--terminal-header-bottom) 100%);
+  border-bottom: 1px solid var(--terminal-header-border);
+}
+
+.mux-chat-drawer-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.mux-chat-drawer-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mux-chat-drawer-clear {
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 4px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  background-color: rgba(255, 255, 255, 0.1);
+  color: var(--terminal-copy-btn-color);
+  cursor: pointer;
+}
+
+.mux-chat-drawer-clear:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.mux-chat-drawer-close {
+  border: none;
+  background: transparent;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--terminal-filename-color);
+}
+
+.mux-chat-drawer-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mux-chat-drawer-empty {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+}
+
+.mux-chat-drawer-limit {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+  text-align: center;
+  padding: 4px 12px;
+  margin: 0;
+}
+
+.mux-chat-drawer-error {
+  font-size: 0.85rem;
+  color: #dc2626;
+  margin: 0;
+}
+
+.mux-chat-message {
+  display: flex;
+}
+
+.mux-chat-message-user {
+  justify-content: flex-end;
+}
+
+.mux-chat-message-assistant {
+  justify-content: flex-start;
+}
+
+.mux-chat-message-bubble {
+  max-width: 80%;
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-size: 0.875rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.mux-chat-message-user .mux-chat-message-bubble {
+  background-color: var(--ifm-color-primary);
+  color: white;
+}
+
+.mux-chat-message-assistant .mux-chat-message-bubble {
+  background-color: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
+  /* Markdown supplies its own block layout; pre-wrap would double the spacing. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+/* Tame default margins on markdown blocks so they sit snugly in the bubble. */
+.mux-chat-message-assistant .mux-chat-message-bubble > :first-child {
+  margin-top: 0;
+}
+
+.mux-chat-message-assistant .mux-chat-message-bubble > :last-child {
+  margin-bottom: 0;
+}
+
+.mux-chat-message-assistant .mux-chat-message-bubble p,
+.mux-chat-message-assistant .mux-chat-message-bubble ul,
+.mux-chat-message-assistant .mux-chat-message-bubble ol {
+  margin: 0 0 8px;
+}
+
+.mux-chat-message-assistant .mux-chat-message-bubble ul,
+.mux-chat-message-assistant .mux-chat-message-bubble ol {
+  padding-left: 1.25rem;
+}
+
+/* Keep highlighted code blocks inside the narrow drawer and readable. */
+.mux-chat-message-assistant .mux-chat-message-bubble pre {
+  margin: 0 0 8px;
+  max-width: 100%;
+  font-size: 0.8rem;
+}
+
+.mux-chat-inline-code {
+  background-color: var(--ifm-color-emphasis-200);
+  border-radius: 4px;
+  padding: 1px 4px;
+  font-size: 0.85em;
+}
+
+.mux-chat-message-content {
+  max-width: 80%;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mux-chat-message-content .mux-chat-message-bubble {
+  max-width: 100%;
+}
+
+.mux-chat-message-sources {
+  padding: 4px 12px 6px;
+  font-size: 0.75rem;
+}
+
+.mux-chat-message-sources-label {
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-600);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.7rem;
+}
+
+.mux-chat-message-sources-list {
+  margin: 2px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mux-chat-message-sources-list li {
+  margin: 0;
+  padding: 0;
+}
+
+.mux-chat-message-sources-link {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.mux-chat-message-sources-link:hover {
+  text-decoration: underline;
+}
+
+.mux-chat-typing {
+  display: flex;
+  gap: 4px;
+  padding: 8px 12px;
+}
+
+.mux-chat-typing-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: var(--ifm-color-emphasis-500);
+  animation: mux-chat-typing-pulse 1.2s infinite ease-in-out;
+}
+
+.mux-chat-typing-dot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.mux-chat-typing-dot:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes mux-chat-typing-pulse {
+  0%, 80%, 100% {
+    opacity: 0.3;
+  }
+  40% {
+    opacity: 1;
+  }
+}
+
+.mux-chat-input-form {
+  display: flex;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.mux-chat-input {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 0.875rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  background-color: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+}
+
+.mux-chat-send-button {
+  padding: 8px 16px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border: none;
+  border-radius: 6px;
+  background-color: var(--ifm-color-primary);
+  color: white;
+  cursor: pointer;
+}
+
+.mux-chat-send-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+[data-theme='dark'] .mux-chat-drawer-clear {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+@media (max-width: 480px) {
+  .mux-chat-drawer {
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    width: auto;
+    max-height: 80vh;
+  }
+
+  .mux-chat-button {
+    right: 16px;
+    bottom: 16px;
+  }
+}

--- a/mux-website/src/hooks/useChat.ts
+++ b/mux-website/src/hooks/useChat.ts
@@ -1,0 +1,100 @@
+import { useCallback, useState } from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { sendChat } from '../api/chat';
+import type { ChatMessage, ChatErrorCode } from '../lib/chatTypes';
+
+const MAX_MESSAGES_PER_SESSION = 25;
+const SESSION_COUNT_KEY = 'mux_chat_message_count';
+
+const ERROR_COPY: Record<ChatErrorCode, string> = {
+  RATE_LIMIT: 'Please wait a moment before sending another message.',
+  MODEL_UNAVAILABLE: 'The AI assistant is temporarily unavailable. Please try again shortly.',
+};
+
+function getSessionCount(): number {
+  try {
+    return parseInt(sessionStorage.getItem(SESSION_COUNT_KEY) ?? '0', 10) || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function incrementSessionCount(): number {
+  try {
+    const next = getSessionCount() + 1;
+    sessionStorage.setItem(SESSION_COUNT_KEY, String(next));
+    return next;
+  } catch {
+    return MAX_MESSAGES_PER_SESSION;
+  }
+}
+
+const useChat = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionCount, setSessionCount] = useState<number>(getSessionCount);
+  const { siteConfig } = useDocusaurusContext();
+  const customFields = siteConfig.customFields;
+  const aiApiUrl =
+    typeof customFields?.aiApiUrl === 'string'
+      ? customFields.aiApiUrl
+      : 'https://mux-ai.corniedj.workers.dev';
+
+  const sessionLimitReached = sessionCount >= MAX_MESSAGES_PER_SESSION;
+
+  const sendMessage = useCallback(
+    async (content: string) => {
+      const trimmed = content.trim();
+      if (!trimmed || sessionLimitReached) {
+        return;
+      }
+
+      const userMessage: ChatMessage = { role: 'user', content: trimmed };
+      const nextMessages = [...messages, userMessage];
+      setMessages(nextMessages);
+      setLoading(true);
+      setError(null);
+
+      const next = incrementSessionCount();
+      setSessionCount(next);
+
+      try {
+        const response = await sendChat(aiApiUrl, nextMessages);
+        if (response.errorCode) {
+          setError(ERROR_COPY[response.errorCode]);
+          return;
+        }
+        if (response.error || !response.message) {
+          setError(response.error ?? 'Server returned an unexpected response');
+          return;
+        }
+        setMessages([
+          ...nextMessages,
+          { role: 'assistant', content: response.message, sources: response.sources ?? [] },
+        ]);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [messages, aiApiUrl, sessionLimitReached],
+  );
+
+  const clearConversation = useCallback(() => {
+    setMessages([]);
+    setError(null);
+  }, []);
+
+  return {
+    messages,
+    loading,
+    error,
+    sessionLimitReached,
+    sendMessage,
+    clearConversation,
+  };
+};
+
+export default useChat;

--- a/mux-website/src/hooks/useChat.ts
+++ b/mux-website/src/hooks/useChat.ts
@@ -25,7 +25,10 @@ function incrementSessionCount(): number {
     sessionStorage.setItem(SESSION_COUNT_KEY, String(next));
     return next;
   } catch {
-    return MAX_MESSAGES_PER_SESSION;
+    // sessionStorage unavailable (e.g. strict private-browsing); degrade
+    // gracefully instead of immediately hitting the limit and locking the user
+    // out permanently after one message.
+    return getSessionCount() + 1;
   }
 }
 

--- a/mux-website/src/hooks/useChat.ts
+++ b/mux-website/src/hooks/useChat.ts
@@ -11,9 +11,13 @@ const ERROR_COPY: Record<ChatErrorCode, string> = {
   MODEL_UNAVAILABLE: 'The AI assistant is temporarily unavailable. Please try again shortly.',
 };
 
+function newId(): string {
+  return crypto.randomUUID();
+}
+
 function getSessionCount(): number {
   try {
-    return parseInt(sessionStorage.getItem(SESSION_COUNT_KEY) ?? '0', 10) || 0;
+    return Number.parseInt(sessionStorage.getItem(SESSION_COUNT_KEY) ?? '0', 10) || 0;
   } catch {
     return 0;
   }
@@ -53,7 +57,7 @@ const useChat = () => {
         return;
       }
 
-      const userMessage: ChatMessage = { role: 'user', content: trimmed };
+      const userMessage: ChatMessage = { id: newId(), role: 'user', content: trimmed };
       const nextMessages = [...messages, userMessage];
       setMessages(nextMessages);
       setLoading(true);
@@ -74,7 +78,7 @@ const useChat = () => {
         }
         setMessages([
           ...nextMessages,
-          { role: 'assistant', content: response.message, sources: response.sources ?? [] },
+          { id: newId(), role: 'assistant', content: response.message, sources: response.sources ?? [] },
         ]);
       } catch (err: unknown) {
         setError(err instanceof Error ? err.message : 'Unknown error');

--- a/mux-website/src/lib/chatTypes.ts
+++ b/mux-website/src/lib/chatTypes.ts
@@ -1,0 +1,23 @@
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  sources?: ChatSource[];
+}
+
+export interface ChatSource {
+  title: string;
+  path: string;
+}
+
+export interface ChatRequest {
+  messages: ChatMessage[];
+}
+
+export type ChatErrorCode = 'RATE_LIMIT' | 'MODEL_UNAVAILABLE';
+
+export interface ChatResponse {
+  message?: string;
+  sources?: ChatSource[];
+  error?: string;
+  errorCode?: ChatErrorCode;
+}

--- a/mux-website/src/lib/chatTypes.ts
+++ b/mux-website/src/lib/chatTypes.ts
@@ -1,4 +1,6 @@
 export interface ChatMessage {
+  /** Stable client-side id, used as the React list key. */
+  id: string;
   role: 'user' | 'assistant';
   content: string;
   sources?: ChatSource[];

--- a/mux-website/src/theme/Root.tsx
+++ b/mux-website/src/theme/Root.tsx
@@ -1,0 +1,15 @@
+import React, { type ReactNode } from 'react';
+import Chat from '../components/Chat';
+
+interface RootProps {
+  children: ReactNode;
+}
+
+export default function Root({ children }: RootProps): ReactNode {
+  return (
+    <>
+      {children}
+      <Chat />
+    </>
+  );
+}

--- a/mux-website/src/theme/Root.tsx
+++ b/mux-website/src/theme/Root.tsx
@@ -5,7 +5,7 @@ interface RootProps {
   children: ReactNode;
 }
 
-export default function Root({ children }: RootProps): ReactNode {
+export default function Root({ children }: Readonly<RootProps>): ReactNode {
   return (
     <>
       {children}

--- a/tools/docs-indexer/.gitignore
+++ b/tools/docs-indexer/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/out

--- a/tools/docs-indexer/README.md
+++ b/tools/docs-indexer/README.md
@@ -1,0 +1,56 @@
+# docs-indexer
+
+Indexes `mux-website/docs/` into the `mux-docs` Vectorize index used by the
+Mux AI assistant. Reads MDX source files directly (no build/crawl of the
+deployed site needed) and excludes `design-notes/` - internal design
+rationale, not language documentation.
+
+This is a manual, on-demand tool. There is no automatic re-indexing; run it
+yourself whenever docs change meaningfully.
+
+## Setup
+
+Create `tools/docs-indexer/.env` (gitignored) with:
+
+```
+CLOUDFLARE_ACCOUNT_ID=<your account id>
+CLOUDFLARE_API_TOKEN=<your token>
+```
+
+The token only needs the **Workers AI: Read** permission - it is used solely
+to generate embeddings via Cloudflare's REST API. Uploading the resulting
+vectors to Vectorize goes through `wrangler vectorize upsert`, which uses
+your existing `wrangler login` session instead - no broader token needed.
+
+```bash
+npm install
+```
+
+## Re-indexing
+
+```bash
+npm run index
+```
+
+This will:
+1. Walk `mux-website/docs/**/*.{md,mdx}` (skipping `design-notes/`).
+2. Strip frontmatter, derive each doc's title and sidebar section.
+3. Chunk each doc into sections that fit the embedding model's context window
+   (~175-450 tokens), preferring heading boundaries.
+4. Embed every chunk with Workers AI (`@cf/baai/bge-base-en-v1.5`).
+5. Write the vectors + metadata to `out/vectors.ndjson`.
+6. Run `wrangler vectorize upsert mux-docs --file out/vectors.ndjson` from
+   `workers/mux-ai`.
+7. Delete any orphaned vectors from the previous run, then record the new
+   vector-id set in `out/manifest.json`.
+
+Each chunk's vector ID is a deterministic hash of its doc id and position, so
+re-running overwrites a doc's existing chunks rather than duplicating them. When
+a doc shrinks to fewer chunks or is removed, the leftover IDs no longer appear
+in the new run; step 7 diffs the new id set against `out/manifest.json` and
+deletes the difference, so the index self-heals without manual cleanup.
+
+`out/manifest.json` is gitignored, so this cleanup is scoped to the machine that
+does the indexing. A fresh checkout with no manifest skips deletion on its first
+run (never destructive by surprise); to force a full purge, delete and recreate
+the `mux-docs` index, then re-index.

--- a/tools/docs-indexer/package-lock.json
+++ b/tools/docs-indexer/package-lock.json
@@ -1,0 +1,619 @@
+{
+  "name": "docs-indexer",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "docs-indexer",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^20.14.0",
+        "dotenv": "^16.4.5",
+        "js-yaml": "^4.1.0",
+        "tsx": "^4.19.0",
+        "typescript": "~5.6.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/docs-indexer/package.json
+++ b/tools/docs-indexer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "docs-indexer",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "index": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20.14.0",
+    "dotenv": "^16.4.5",
+    "js-yaml": "^4.1.0",
+    "tsx": "^4.19.0",
+    "typescript": "~5.6.2"
+  }
+}

--- a/tools/docs-indexer/src/chunk.ts
+++ b/tools/docs-indexer/src/chunk.ts
@@ -39,7 +39,7 @@ function splitIntoSections(content: string): Section[] {
   };
 
   for (const line of lines) {
-    const headingMatch = /^(#{1,6})\s+(.+)$/.exec(line);
+    const headingMatch = /^(#{1,6})[ \t]+(\S.*)$/.exec(line);
     if (headingMatch) {
       flush();
       currentHeading = headingMatch[2].trim();

--- a/tools/docs-indexer/src/chunk.ts
+++ b/tools/docs-indexer/src/chunk.ts
@@ -1,0 +1,102 @@
+/**
+ * Token counts aren't computed exactly (no tokenizer dependency); ~4 chars
+ * per token is a standard approximation for English prose and code fences,
+ * which is precise enough for picking chunk boundaries.
+ *
+ * Chunks must fit the embedding model's context window (bge-base-en-v1.5 reads
+ * at most 512 tokens), or the tail of a chunk never influences its vector and
+ * becomes unfindable by search. The max target is held at ~450 tokens to leave
+ * headroom for the query instruction prefix and for code, which is denser than
+ * the 4-chars-per-token estimate.
+ */
+const CHARS_PER_TOKEN = 4;
+const MIN_CHARS = 175 * CHARS_PER_TOKEN;
+const MAX_CHARS = 450 * CHARS_PER_TOKEN;
+
+export interface Chunk {
+  text: string;
+  /** Nearest heading above this chunk, if any. */
+  heading: string | null;
+}
+
+interface Section {
+  heading: string | null;
+  text: string;
+}
+
+function splitIntoSections(content: string): Section[] {
+  const lines = content.split('\n');
+  const sections: Section[] = [];
+  let currentHeading: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    const text = currentLines.join('\n').trim();
+    if (text) {
+      sections.push({ heading: currentHeading, text });
+    }
+    currentLines = [];
+  };
+
+  for (const line of lines) {
+    const headingMatch = /^(#{1,6})\s+(.+)$/.exec(line);
+    if (headingMatch) {
+      flush();
+      currentHeading = headingMatch[2].trim();
+    }
+    currentLines.push(line);
+  }
+  flush();
+
+  return sections;
+}
+
+function splitOversizedSection(section: Section): Section[] {
+  const paragraphs = section.text.split(/\n{2,}/);
+  const result: Section[] = [];
+  let buffer = '';
+
+  for (const paragraph of paragraphs) {
+    const candidate = buffer ? `${buffer}\n\n${paragraph}` : paragraph;
+    if (candidate.length > MAX_CHARS && buffer) {
+      result.push({ heading: section.heading, text: buffer });
+      buffer = paragraph;
+    } else {
+      buffer = candidate;
+    }
+  }
+  if (buffer) {
+    result.push({ heading: section.heading, text: buffer });
+  }
+
+  return result;
+}
+
+export function chunkContent(content: string): Chunk[] {
+  const rawSections = splitIntoSections(content).flatMap((section) =>
+    section.text.length > MAX_CHARS ? splitOversizedSection(section) : [section],
+  );
+
+  const chunks: Chunk[] = [];
+  let buffer: Section | null = null;
+
+  for (const section of rawSections) {
+    if (!buffer) {
+      buffer = { ...section };
+      continue;
+    }
+
+    const merged: string = `${buffer.text}\n\n${section.text}`;
+    if (buffer.text.length < MIN_CHARS && merged.length <= MAX_CHARS) {
+      buffer = { heading: buffer.heading, text: merged };
+    } else {
+      chunks.push({ text: buffer.text, heading: buffer.heading });
+      buffer = { ...section };
+    }
+  }
+  if (buffer) {
+    chunks.push({ text: buffer.text, heading: buffer.heading });
+  }
+
+  return chunks;
+}

--- a/tools/docs-indexer/src/crawl.ts
+++ b/tools/docs-indexer/src/crawl.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const EXCLUDED_SOURCES = new Set(['design-notes']);
+
+export interface DocFile {
+  absPath: string;
+  /** Doc id relative to the docs root, no extension, e.g. "tour/enums" */
+  docId: string;
+}
+
+function walk(dir: string, root: string, results: DocFile[]): void {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (EXCLUDED_SOURCES.has(entry.name)) {
+        continue;
+      }
+      walk(fullPath, root, results);
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (!entry.name.endsWith('.md') && !entry.name.endsWith('.mdx')) {
+      continue;
+    }
+
+    const relPath = path.relative(root, fullPath);
+    const topLevelDir = relPath.split(path.sep)[0];
+    if (EXCLUDED_SOURCES.has(topLevelDir)) {
+      continue;
+    }
+
+    const docId = relPath.replace(/\.mdx?$/, '').split(path.sep).join('/');
+    results.push({ absPath: fullPath, docId });
+  }
+}
+
+export function crawlDocs(docsRoot: string): DocFile[] {
+  const results: DocFile[] = [];
+  walk(docsRoot, docsRoot, results);
+  return results;
+}

--- a/tools/docs-indexer/src/embed.ts
+++ b/tools/docs-indexer/src/embed.ts
@@ -1,0 +1,54 @@
+const EMBEDDING_MODEL = '@cf/baai/bge-base-en-v1.5';
+const MAX_BATCH_SIZE = 100;
+
+interface WorkersAiEmbeddingResponse {
+  success: boolean;
+  errors?: { message: string }[];
+  result?: {
+    shape: [number, number];
+    data: number[][];
+  };
+}
+
+async function embedBatch(
+  texts: string[],
+  accountId: string,
+  apiToken: string,
+): Promise<number[][]> {
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run/${EMBEDDING_MODEL}`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text: texts }),
+    },
+  );
+
+  const data = (await res.json()) as WorkersAiEmbeddingResponse;
+
+  if (!res.ok || !data.success || !data.result) {
+    const message = data.errors?.map((e) => e.message).join('; ') || `HTTP ${res.status}`;
+    throw new Error(`Workers AI embedding request failed: ${message}`);
+  }
+
+  return data.result.data;
+}
+
+export async function embedTexts(
+  texts: string[],
+  accountId: string,
+  apiToken: string,
+): Promise<number[][]> {
+  const vectors: number[][] = [];
+
+  for (let i = 0; i < texts.length; i += MAX_BATCH_SIZE) {
+    const batch = texts.slice(i, i + MAX_BATCH_SIZE);
+    const batchVectors = await embedBatch(batch, accountId, apiToken);
+    vectors.push(...batchVectors);
+  }
+
+  return vectors;
+}

--- a/tools/docs-indexer/src/extract.ts
+++ b/tools/docs-indexer/src/extract.ts
@@ -13,7 +13,7 @@ export interface ExtractedDoc {
 }
 
 function parseFrontMatter(raw: string): { frontMatter: Record<string, unknown>; content: string } {
-  const match = /^---\s*\r?\n([\s\S]*?)\r?\n---\s*(?:\r?\n|$)/.exec(raw.slice(0, 10240));
+  const match = /^---[ \t]*\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/.exec(raw.slice(0, 10240));
   if (!match) {
     return { frontMatter: {}, content: raw.trim() };
   }
@@ -38,7 +38,7 @@ function deriveTitle(docId: string, frontMatter: Record<string, unknown>, conten
     return frontMatter.title.trim();
   }
 
-  const headingMatch = /^#\s+(.+)$/m.exec(content);
+  const headingMatch = /^#[ \t]+(\S.*)$/m.exec(content);
   if (headingMatch) {
     return headingMatch[1].trim();
   }

--- a/tools/docs-indexer/src/extract.ts
+++ b/tools/docs-indexer/src/extract.ts
@@ -1,0 +1,72 @@
+import fs from 'node:fs';
+import { load as loadYaml } from 'js-yaml';
+import type { DocFile } from './crawl';
+import { sectionForDocId } from './sidebarSections';
+
+export interface ExtractedDoc {
+  docId: string;
+  /** Site-relative path, e.g. "/docs/tour/enums/" */
+  docPath: string;
+  title: string;
+  section: string;
+  content: string;
+}
+
+function parseFrontMatter(raw: string): { frontMatter: Record<string, unknown>; content: string } {
+  const match = /^---\s*\r?\n([\s\S]*?)\r?\n---\s*(?:\r?\n|$)/.exec(raw.slice(0, 10240));
+  if (!match) {
+    return { frontMatter: {}, content: raw.trim() };
+  }
+
+  try {
+    const parsed = loadYaml(match[1]);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return {
+        frontMatter: parsed as Record<string, unknown>,
+        content: raw.slice(match[0].length).trim(),
+      };
+    }
+  } catch {
+    // Fall through to returning raw content with no front matter.
+  }
+
+  return { frontMatter: {}, content: raw.slice(match[0].length).trim() };
+}
+
+function deriveTitle(docId: string, frontMatter: Record<string, unknown>, content: string): string {
+  if (typeof frontMatter.title === 'string' && frontMatter.title.trim()) {
+    return frontMatter.title.trim();
+  }
+
+  const headingMatch = /^#\s+(.+)$/m.exec(content);
+  if (headingMatch) {
+    return headingMatch[1].trim();
+  }
+
+  const lastSegment = docId.split('/').pop() ?? docId;
+  return lastSegment
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function docPathForId(docId: string): string {
+  if (docId === 'index') {
+    return '/docs/';
+  }
+  return `/docs/${docId}/`;
+}
+
+export function extractDoc(file: DocFile): ExtractedDoc {
+  const raw = fs.readFileSync(file.absPath, 'utf8');
+  const { frontMatter, content } = parseFrontMatter(raw);
+  const title = deriveTitle(file.docId, frontMatter, content);
+
+  return {
+    docId: file.docId,
+    docPath: docPathForId(file.docId),
+    title,
+    section: sectionForDocId(file.docId),
+    content,
+  };
+}

--- a/tools/docs-indexer/src/index.ts
+++ b/tools/docs-indexer/src/index.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import 'dotenv/config';
+import { crawlDocs } from './crawl';
+import { extractDoc } from './extract';
+import { chunkContent } from './chunk';
+import { embedTexts } from './embed';
+import {
+  writeNdjson,
+  upsertToVectorize,
+  vectorIds,
+  readManifest,
+  writeManifest,
+  computeStaleIds,
+  deleteVectors,
+  type IndexedChunk,
+} from './upload';
+
+const DOCS_ROOT = path.resolve(import.meta.dirname, '..', '..', '..', 'mux-website', 'docs');
+
+async function main(): Promise<void> {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+
+  if (!accountId || !apiToken) {
+    throw new Error(
+      'CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN must be set (see tools/docs-indexer/.env)',
+    );
+  }
+
+  const files = crawlDocs(DOCS_ROOT);
+  console.log(`Found ${files.length} doc files`);
+
+  const docs = files.map(extractDoc);
+
+  const pending: { doc: (typeof docs)[number]; chunk: ReturnType<typeof chunkContent>[number]; chunkIndex: number }[] = [];
+  for (const doc of docs) {
+    const chunks = chunkContent(doc.content);
+    chunks.forEach((chunk, chunkIndex) => {
+      pending.push({ doc, chunk, chunkIndex });
+    });
+  }
+  console.log(`Chunked into ${pending.length} chunks`);
+
+  const texts = pending.map((entry) => entry.chunk.text);
+  console.log('Generating embeddings via Workers AI...');
+  const vectors = await embedTexts(texts, accountId, apiToken);
+
+  if (vectors.length !== pending.length) {
+    throw new Error(
+      `Embedding count mismatch: expected ${pending.length}, got ${vectors.length}`,
+    );
+  }
+
+  const indexed: IndexedChunk[] = pending.map((entry, i) => ({
+    doc: entry.doc,
+    chunk: entry.chunk,
+    chunkIndex: entry.chunkIndex,
+    vector: vectors[i],
+  }));
+
+  const ndjsonPath = writeNdjson(indexed);
+  console.log(`Wrote ${indexed.length} vectors to ${ndjsonPath}`);
+
+  // Capture orphans (old run minus new run) before overwriting the manifest.
+  const newIds = vectorIds(indexed);
+  const staleIds = computeStaleIds(readManifest(), newIds);
+
+  console.log('Upserting to Vectorize index "mux-docs"...');
+  upsertToVectorize(ndjsonPath);
+
+  if (staleIds.length > 0) {
+    console.log(`Deleting ${staleIds.length} stale vectors from the previous run...`);
+    deleteVectors(staleIds);
+  } else {
+    console.log('No stale vectors to delete.');
+  }
+
+  // Only record the new manifest after upsert + delete succeeded; if either
+  // threw, the old manifest stays so the next run retries the cleanup.
+  writeManifest(newIds);
+
+  console.log('Done.');
+}
+
+main().catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exitCode = 1;
+});

--- a/tools/docs-indexer/src/sidebarSections.ts
+++ b/tools/docs-indexer/src/sidebarSections.ts
@@ -1,0 +1,81 @@
+/**
+ * Maps a doc id (e.g. "tour/enums") to the section label shown in the
+ * Docusaurus sidebar (mux-website/sidebars.ts). Mirrors that file's manually
+ * curated structure rather than inferring from folder names, since the
+ * sidebar itself is hand-curated and doesn't always match the directory
+ * layout 1:1.
+ *
+ * Docs not listed here (orphan pages not yet added to the sidebar) fall back
+ * to a title-cased version of their top-level directory.
+ */
+const SIDEBAR_SECTIONS: Record<string, string> = {
+  index: 'Introduction',
+  setup: 'Setup',
+
+  'getting-started/why-mux': 'Getting Started',
+  'getting-started/quick-start': 'Getting Started',
+
+  'tour/tour': 'Tour of Mux',
+  'tour/hello-world': 'Tour of Mux',
+  'tour/variables': 'Tour of Mux',
+  'tour/basic-types': 'Tour of Mux',
+  'tour/functions': 'Tour of Mux',
+  'tour/control-flow': 'Tour of Mux',
+  'tour/lists': 'Tour of Mux',
+  'tour/maps': 'Tour of Mux',
+  'tour/sets': 'Tour of Mux',
+  'tour/classes': 'Tour of Mux',
+  'tour/enums': 'Tour of Mux',
+  'tour/generics': 'Tour of Mux',
+  'tour/error-handling': 'Tour of Mux',
+  'tour/interfaces': 'Tour of Mux',
+  'tour/references': 'Tour of Mux',
+  'tour/modules': 'Tour of Mux',
+  'tour/next-steps': 'Tour of Mux',
+
+  'reference/overview': 'Language Reference',
+  'reference/lexical-structure': 'Language Reference',
+  'reference/expressions': 'Language Reference',
+  'reference/statements': 'Language Reference',
+  'reference/operators': 'Language Reference',
+  'reference/memory-model': 'Language Reference',
+
+  'language-guide/overview': 'Language Guide',
+  'language-guide/types': 'Language Guide',
+  'language-guide/variables': 'Language Guide',
+  'language-guide/operators': 'Language Guide',
+  'language-guide/functions': 'Language Guide',
+  'language-guide/control-flow': 'Language Guide',
+  'language-guide/classes': 'Language Guide',
+  'language-guide/enums': 'Language Guide',
+  'language-guide/generics': 'Language Guide',
+  'language-guide/collections': 'Language Guide',
+  'language-guide/error-handling': 'Language Guide',
+  'language-guide/memory': 'Language Guide',
+  'language-guide/modules': 'Language Guide',
+
+  'stdlib/index': 'Standard Library',
+  'stdlib/math': 'Standard Library',
+  'stdlib/io': 'Standard Library',
+  'stdlib/net': 'Standard Library',
+  'stdlib/sql': 'Standard Library',
+  'stdlib/random': 'Standard Library',
+  'stdlib/datetime': 'Standard Library',
+  'stdlib/dsa': 'Standard Library',
+};
+
+function titleCase(segment: string): string {
+  return segment
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export function sectionForDocId(docId: string): string {
+  const known = SIDEBAR_SECTIONS[docId];
+  if (known) {
+    return known;
+  }
+  const topLevelDir = docId.split('/')[0];
+  return titleCase(topLevelDir);
+}

--- a/tools/docs-indexer/src/upload.ts
+++ b/tools/docs-indexer/src/upload.ts
@@ -1,0 +1,120 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ExtractedDoc } from './extract';
+import type { Chunk } from './chunk';
+
+export interface IndexedChunk {
+  doc: ExtractedDoc;
+  chunk: Chunk;
+  chunkIndex: number;
+  vector: number[];
+}
+
+interface VectorizeRecord {
+  id: string;
+  values: number[];
+  metadata: {
+    docId: string;
+    title: string;
+    path: string;
+    section: string;
+    heading: string | null;
+    text: string;
+  };
+}
+
+function vectorId(docId: string, chunkIndex: number): string {
+  return createHash('sha1').update(`${docId}:${chunkIndex}`).digest('hex');
+}
+
+function toRecord(entry: IndexedChunk): VectorizeRecord {
+  return {
+    id: vectorId(entry.doc.docId, entry.chunkIndex),
+    values: entry.vector,
+    metadata: {
+      docId: entry.doc.docId,
+      title: entry.doc.title,
+      path: entry.doc.docPath,
+      section: entry.doc.section,
+      heading: entry.chunk.heading,
+      text: entry.chunk.text,
+    },
+  };
+}
+
+const WORKER_DIR = path.resolve(import.meta.dirname, '..', '..', '..', 'workers', 'mux-ai');
+const OUT_DIR = path.resolve(import.meta.dirname, '..', 'out');
+const NDJSON_PATH = path.join(OUT_DIR, 'vectors.ndjson');
+// Records the full set of vector IDs from the last run so the next run can
+// delete orphans (chunks of docs that shrank or were removed). Lives in the
+// gitignored out/ dir, so cleanup is scoped to the machine that does the
+// indexing; a fresh checkout with no manifest skips deletion (never destructive
+// by surprise) and a full purge can be forced by deleting the index.
+const MANIFEST_PATH = path.join(OUT_DIR, 'manifest.json');
+// Vectorize caps deleteByIds per request; batch well under any limit.
+const DELETE_BATCH_SIZE = 500;
+
+export function writeNdjson(entries: IndexedChunk[]): string {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const lines = entries.map((entry) => JSON.stringify(toRecord(entry)));
+  fs.writeFileSync(NDJSON_PATH, lines.join('\n') + '\n', 'utf8');
+  return NDJSON_PATH;
+}
+
+export function vectorIds(entries: IndexedChunk[]): string[] {
+  return entries.map((entry) => vectorId(entry.doc.docId, entry.chunkIndex));
+}
+
+export function readManifest(): string[] | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(MANIFEST_PATH, 'utf8'));
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed.filter((id): id is string => typeof id === 'string');
+  } catch {
+    return null;
+  }
+}
+
+export function writeManifest(ids: string[]): void {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.writeFileSync(MANIFEST_PATH, JSON.stringify(ids), 'utf8');
+}
+
+/** IDs present in the previous run but not the current one (orphans to delete). */
+export function computeStaleIds(oldIds: string[] | null, newIds: string[]): string[] {
+  if (!oldIds) {
+    return [];
+  }
+  const current = new Set(newIds);
+  return oldIds.filter((id) => !current.has(id));
+}
+
+// Strip the local embedding-only API token so wrangler falls back to the
+// `wrangler login` OAuth session, which has Vectorize permissions.
+function wranglerEnv(): NodeJS.ProcessEnv {
+  const { CLOUDFLARE_API_TOKEN: _unused, ...env } = process.env;
+  return env;
+}
+
+export function upsertToVectorize(ndjsonPath: string): void {
+  execFileSync(
+    'npx',
+    ['wrangler', 'vectorize', 'upsert', 'mux-docs', '--file', ndjsonPath],
+    { cwd: WORKER_DIR, stdio: 'inherit', env: wranglerEnv() },
+  );
+}
+
+export function deleteVectors(ids: string[]): void {
+  for (let i = 0; i < ids.length; i += DELETE_BATCH_SIZE) {
+    const batch = ids.slice(i, i + DELETE_BATCH_SIZE);
+    execFileSync(
+      'npx',
+      ['wrangler', 'vectorize', 'delete-vectors', 'mux-docs', '--ids', ...batch],
+      { cwd: WORKER_DIR, stdio: 'inherit', env: wranglerEnv() },
+    );
+  }
+}

--- a/tools/docs-indexer/src/upload.ts
+++ b/tools/docs-indexer/src/upload.ts
@@ -26,7 +26,9 @@ interface VectorizeRecord {
 }
 
 function vectorId(docId: string, chunkIndex: number): string {
-  return createHash('sha1').update(`${docId}:${chunkIndex}`).digest('hex');
+  // SHA-256 (not SHA-1) purely as a stable, collision-resistant id for the
+  // chunk; not a security context, but avoids flagging a weak hash algorithm.
+  return createHash('sha256').update(`${docId}:${chunkIndex}`).digest('hex');
 }
 
 function toRecord(entry: IndexedChunk): VectorizeRecord {
@@ -93,6 +95,11 @@ export function computeStaleIds(oldIds: string[] | null, newIds: string[]): stri
   return oldIds.filter((id) => !current.has(id));
 }
 
+// Absolute path to the wrangler binary installed in the worker package, so the
+// command does not rely on PATH resolution (which could pick up an attacker-
+// controlled `npx`/`wrangler` earlier on PATH).
+const WRANGLER_BIN = path.join(WORKER_DIR, 'node_modules', '.bin', 'wrangler');
+
 // Strip the local embedding-only API token so wrangler falls back to the
 // `wrangler login` OAuth session, which has Vectorize permissions.
 function wranglerEnv(): NodeJS.ProcessEnv {
@@ -102,8 +109,8 @@ function wranglerEnv(): NodeJS.ProcessEnv {
 
 export function upsertToVectorize(ndjsonPath: string): void {
   execFileSync(
-    'npx',
-    ['wrangler', 'vectorize', 'upsert', 'mux-docs', '--file', ndjsonPath],
+    WRANGLER_BIN,
+    ['vectorize', 'upsert', 'mux-docs', '--file', ndjsonPath],
     { cwd: WORKER_DIR, stdio: 'inherit', env: wranglerEnv() },
   );
 }
@@ -112,8 +119,8 @@ export function deleteVectors(ids: string[]): void {
   for (let i = 0; i < ids.length; i += DELETE_BATCH_SIZE) {
     const batch = ids.slice(i, i + DELETE_BATCH_SIZE);
     execFileSync(
-      'npx',
-      ['wrangler', 'vectorize', 'delete-vectors', 'mux-docs', '--ids', ...batch],
+      WRANGLER_BIN,
+      ['vectorize', 'delete-vectors', 'mux-docs', '--ids', ...batch],
       { cwd: WORKER_DIR, stdio: 'inherit', env: wranglerEnv() },
     );
   }

--- a/tools/docs-indexer/tsconfig.json
+++ b/tools/docs-indexer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["node"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tools/retrieval-test/.gitignore
+++ b/tools/retrieval-test/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/tools/retrieval-test/README.md
+++ b/tools/retrieval-test/README.md
@@ -1,0 +1,41 @@
+# retrieval-test
+
+Evaluation harness for the `mux-docs` Vectorize retrieval layer. Runs a fixed
+question set against the Worker's `POST /api/search` endpoint and asserts:
+
+- **Positive cases**: the expected doc appears in the top-k results, and the
+  best matching hit clears a healthy score margin (early warning before a
+  relevant doc actually falls below the Worker's `MIN_SCORE` floor).
+- **Negative cases**: off-topic queries retrieve nothing, guarding both the
+  off-topic rejection path and the threshold calibration.
+
+This is the regression guard for any change to the embedding model, the query
+instruction prefix, chunking, or the score floor. After re-indexing, run it and
+confirm it stays green; if the score distribution shifted, it fails loudly.
+
+## Running
+
+`/api/search` is gated to `ENVIRONMENT=development` and does not exist in
+production, so the eval runs against a local dev Worker. Vectorize and Workers
+AI have no local emulation, so the dev Worker needs `--remote` to reach the real
+`mux-docs` index:
+
+```bash
+# Terminal 1 - dev Worker bound to the real index
+cd workers/mux-ai
+npx wrangler dev --env development --remote
+
+# Terminal 2 - run the eval
+cd tools/retrieval-test
+npm install   # first time only
+npm run eval
+```
+
+The eval defaults to `http://localhost:8787`. Override with `SEARCH_URL` if the
+dev Worker is on another port:
+
+```bash
+SEARCH_URL=http://localhost:9000 npm run eval
+```
+
+Exit code is non-zero if any case fails, so it is CI-friendly.

--- a/tools/retrieval-test/package-lock.json
+++ b/tools/retrieval-test/package-lock.json
@@ -1,0 +1,566 @@
+{
+  "name": "retrieval-test",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "retrieval-test",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "tsx": "^4.19.0",
+        "typescript": "~5.6.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tools/retrieval-test/package.json
+++ b/tools/retrieval-test/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "retrieval-test",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "eval": "tsx src/run.ts",
+    "error-eval": "tsx src/error-eval.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "tsx": "^4.19.0",
+    "typescript": "~5.6.2"
+  }
+}

--- a/tools/retrieval-test/src/error-eval.ts
+++ b/tools/retrieval-test/src/error-eval.ts
@@ -1,0 +1,128 @@
+/**
+ * Error-explainer evaluation harness.
+ *
+ * Feeds each fixture in docs/error-corpus/*.json to POST /api/chat as if a user
+ * pasted the compiler error, and asserts:
+ *   - the model actually explained it (not the "couldn't find" refusal), and
+ *   - when the fixture lists relevant_docs, at least one is cited in sources.
+ *
+ * Runs against the same local dev Worker as the retrieval eval (see README):
+ *
+ *   Terminal 1:  cd workers/mux-ai && npx wrangler dev --env development --remote
+ *   Terminal 2:  cd tools/retrieval-test && npm run error-eval
+ *
+ * Override the target with WORKER_URL if the dev Worker is on another port.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+interface ErrorCase {
+  id: string;
+  source: string;
+  error: string;
+  help: string | null;
+  category: string;
+  relevant_docs: string[];
+}
+
+interface ChatSource {
+  title: string;
+  path: string;
+}
+
+interface ChatResponse {
+  message?: string;
+  sources?: ChatSource[];
+  error?: string;
+}
+
+const DEFAULT_URL = 'http://localhost:8787';
+const CORPUS_DIR = path.resolve(import.meta.dirname, '..', '..', '..', 'docs', 'error-corpus');
+const REFUSAL_MARKER = "couldn't find that information";
+
+function loadCorpus(): ErrorCase[] {
+  const files = fs.readdirSync(CORPUS_DIR).filter((f) => f.endsWith('.json'));
+  const cases: ErrorCase[] = [];
+  for (const file of files) {
+    const parsed: unknown = JSON.parse(fs.readFileSync(path.join(CORPUS_DIR, file), 'utf8'));
+    if (Array.isArray(parsed)) {
+      cases.push(...(parsed as ErrorCase[]));
+    }
+  }
+  return cases;
+}
+
+function buildErrorMessage(c: ErrorCase): string {
+  const help = c.help ? `\n  = help: ${c.help}` : '';
+  return `I got this compiler error, what does it mean and how do I fix it?\n\nerror: ${c.error}\n${c.source}${help}`;
+}
+
+async function askChat(baseUrl: string, content: string): Promise<ChatResponse> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const res = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: [{ role: 'user', content }] }),
+    });
+    if (res.status === 429) {
+      // Per-IP cooldown; wait past it and retry once.
+      await new Promise((r) => setTimeout(r, 2500));
+      continue;
+    }
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+    }
+    return (await res.json()) as ChatResponse;
+  }
+  throw new Error('rate limited after retry');
+}
+
+function evaluate(c: ErrorCase, res: ChatResponse): { pass: boolean; reason: string } {
+  const message = res.message ?? '';
+  if (message.toLowerCase().includes(REFUSAL_MARKER)) {
+    return { pass: false, reason: 'model refused to explain' };
+  }
+  const citedPaths = (res.sources ?? []).map((s) => s.path);
+  if (c.relevant_docs.length > 0) {
+    const matched = c.relevant_docs.find((d) => citedPaths.includes(d));
+    if (!matched) {
+      return {
+        pass: false,
+        reason: `none of ${JSON.stringify(c.relevant_docs)} cited; got ${JSON.stringify(citedPaths)}`,
+      };
+    }
+    return { pass: true, reason: `cited ${matched}` };
+  }
+  return { pass: true, reason: citedPaths.length ? `cited ${citedPaths[0]}` : 'explained' };
+}
+
+async function main(): Promise<void> {
+  const baseUrl = (process.env.WORKER_URL ?? DEFAULT_URL).replace(/\/$/, '');
+  const corpus = loadCorpus();
+  console.log(`Target: ${baseUrl}  (${corpus.length} error fixtures)\n`);
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const c of corpus) {
+    try {
+      const res = await askChat(baseUrl, buildErrorMessage(c));
+      const { pass, reason } = evaluate(c, res);
+      console.log(`${pass ? 'PASS' : 'FAIL'}  [${c.category}] ${c.id} - ${reason}`);
+      pass ? passed++ : failed++;
+    } catch (err) {
+      console.error(`ERROR [${c.category}] ${c.id} - ${String(err)}`);
+      failed++;
+    }
+  }
+
+  console.log(`\nResult: ${passed}/${passed + failed} passed`);
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/retrieval-test/src/run.ts
+++ b/tools/retrieval-test/src/run.ts
@@ -1,0 +1,181 @@
+/**
+ * Retrieval evaluation harness for the mux-docs Vectorize index.
+ *
+ * Hits POST /api/search on the Worker (local or prod) with a fixed question
+ * set and checks:
+ *   - positive cases: the expected doc appears in the top-k AND the best
+ *     matching hit clears a healthy score margin (early warning before a
+ *     relevant doc actually falls below the Worker's MIN_SCORE floor).
+ *   - negative cases: off-topic queries retrieve nothing, guarding both the
+ *     off-topic rejection path and the threshold calibration.
+ *
+ * /api/search is gated to ENVIRONMENT=development, so this runs against a local
+ * dev Worker, not production. Vectorize/Workers AI have no local emulation, so
+ * the dev Worker must run with --remote to hit the real mux-docs index:
+ *
+ *   Terminal 1:  cd workers/mux-ai && npx wrangler dev --env development --remote
+ *   Terminal 2:  cd tools/retrieval-test && npm run eval
+ *
+ * Override the target with SEARCH_URL if the dev Worker is on another port.
+ */
+
+interface SearchResult {
+  title: string;
+  path: string;
+  section: string;
+  heading: string | null;
+  score: number;
+}
+
+interface SearchResponse {
+  results: SearchResult[];
+}
+
+interface PositiveCase {
+  question: string;
+  // At least one result must contain this string in its path/title/heading.
+  expectedMatch: string;
+}
+
+const POSITIVE_CASES: PositiveCase[] = [
+  { question: 'How do enums work?', expectedMatch: 'enum' },
+  { question: 'How do generics work?', expectedMatch: 'generic' },
+  { question: 'What is match and how do I use it?', expectedMatch: 'match' },
+  // Mux uses "interfaces" (keyword: is) documented inside classes.md
+  { question: 'How do I define and implement an interface?', expectedMatch: 'class' },
+  { question: 'How do modules work?', expectedMatch: 'module' },
+];
+
+// Off-topic queries that must retrieve nothing. If the Worker's MIN_SCORE floor
+// is set too low (or the distribution shifts), these start leaking hits and the
+// eval fails loudly.
+const NEGATIVE_CASES: string[] = [
+  'what is the weather in Paris today',
+  'how do I bake sourdough bread',
+  'tell me about quantum entanglement',
+];
+
+// The relevant hit for a positive case must score at least this high. Kept
+// above the Worker's MIN_SCORE so the eval warns while there is still margin,
+// instead of only after a relevant doc has already dropped below the floor.
+const MIN_HEALTHY_SCORE = 0.63;
+
+const DEFAULT_SEARCH_URL = 'http://localhost:8787';
+const TOP_K = 5;
+
+async function search(baseUrl: string, question: string): Promise<SearchResult[]> {
+  const res = await fetch(`${baseUrl}/api/search`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: question }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status}: ${text}`);
+  }
+
+  const data = (await res.json()) as SearchResponse;
+  return data.results;
+}
+
+function resultHit(result: SearchResult, expectedMatch: string): boolean {
+  const needle = expectedMatch.toLowerCase();
+  return (
+    result.path.toLowerCase().includes(needle) ||
+    result.title.toLowerCase().includes(needle) ||
+    (result.heading?.toLowerCase().includes(needle) ?? false)
+  );
+}
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + ' '.repeat(width - s.length);
+}
+
+function printResults(results: SearchResult[], expectedMatch: string | null): void {
+  results.slice(0, TOP_K).forEach((r, i) => {
+    const marker = expectedMatch && resultHit(r, expectedMatch) ? '*' : ' ';
+    console.log(`  ${marker} ${i + 1}. [${r.score.toFixed(4)}] ${pad(r.title, 35)} ${r.path}`);
+  });
+}
+
+interface Outcome {
+  pass: boolean;
+}
+
+function runPositive(tc: PositiveCase, results: SearchResult[]): Outcome {
+  const topK = results.slice(0, TOP_K);
+  const matches = topK.filter((r) => resultHit(r, tc.expectedMatch));
+
+  if (matches.length === 0) {
+    console.log(`FAIL  "${tc.question}" - no result matching "${tc.expectedMatch}" in top ${TOP_K}`);
+    printResults(results, tc.expectedMatch);
+    return { pass: false };
+  }
+
+  const bestScore = Math.max(...matches.map((r) => r.score));
+  if (bestScore < MIN_HEALTHY_SCORE) {
+    console.log(
+      `FAIL  "${tc.question}" - best match ${bestScore.toFixed(4)} below healthy margin ${MIN_HEALTHY_SCORE}`,
+    );
+    printResults(results, tc.expectedMatch);
+    return { pass: false };
+  }
+
+  console.log(`PASS  "${tc.question}" (best match ${bestScore.toFixed(4)})`);
+  printResults(results, tc.expectedMatch);
+  return { pass: true };
+}
+
+function runNegative(question: string, results: SearchResult[]): Outcome {
+  if (results.length > 0) {
+    console.log(`FAIL  [off-topic] "${question}" - expected 0 results, got ${results.length}`);
+    printResults(results, null);
+    return { pass: false };
+  }
+  console.log(`PASS  [off-topic] "${question}" - 0 results`);
+  return { pass: true };
+}
+
+async function main(): Promise<void> {
+  const baseUrl = (process.env.SEARCH_URL ?? DEFAULT_SEARCH_URL).replace(/\/$/, '');
+  console.log(`Target: ${baseUrl}\n`);
+
+  let passed = 0;
+  let failed = 0;
+
+  for (const tc of POSITIVE_CASES) {
+    try {
+      const results = await search(baseUrl, tc.question);
+      const { pass } = runPositive(tc, results);
+      pass ? passed++ : failed++;
+    } catch (err) {
+      console.error(`ERROR "${tc.question}"\n      ${String(err)}`);
+      failed++;
+    }
+    console.log();
+  }
+
+  for (const question of NEGATIVE_CASES) {
+    try {
+      const results = await search(baseUrl, question);
+      const { pass } = runNegative(question, results);
+      pass ? passed++ : failed++;
+    } catch (err) {
+      console.error(`ERROR [off-topic] "${question}"\n      ${String(err)}`);
+      failed++;
+    }
+    console.log();
+  }
+
+  const total = passed + failed;
+  console.log(`Result: ${passed}/${total} passed`);
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/retrieval-test/tsconfig.json
+++ b/tools/retrieval-test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/workers/mux-ai/.gitignore
+++ b/workers/mux-ai/.gitignore
@@ -1,0 +1,11 @@
+# Dependencies
+/node_modules
+
+# Wrangler local state
+/.wrangler
+
+# Local secrets for wrangler dev
+.dev.vars
+.dev.vars.*
+
+.DS_Store

--- a/workers/mux-ai/README.md
+++ b/workers/mux-ai/README.md
@@ -1,0 +1,120 @@
+# mux-ai
+
+Cloudflare Worker backing the Mux AI documentation assistant. Lives on its own
+free-tier Cloudflare account/Worker, separate from the billed `mux-lang-api`
+Fly.io service, so the assistant's usage never affects compile-API costs.
+
+The assistant spans four pieces:
+
+- `workers/mux-ai` (this dir) - the Worker: retrieval + answer generation.
+- `tools/docs-indexer` - embeds `mux-website/docs/` into the `mux-docs`
+  Vectorize index.
+- `tools/retrieval-test` - eval harness (retrieval + error-explainer).
+- `mux-website/src/components/Chat` - the chat widget.
+
+## Setup (already done for this account)
+
+- Worker `mux-ai` created at `https://mux-ai.corniedj.workers.dev/`.
+- Workers AI enabled on the account.
+- Vectorize index `mux-docs` created (cosine, 768 dimensions), bound as `VECTORIZE`.
+
+## Endpoints
+
+- `GET /api/chat/health` - returns `{ "status": "ok" }`.
+- `POST /api/chat` - retrieval-augmented chat. Embeds the query (with the last
+  few user turns for context), queries Vectorize for the top chunks above
+  `MIN_SCORE`, and generates a grounded answer with `sources`. Rate-limited per
+  IP, with a per-message size cap and a bounded conversation history.
+- `POST /api/search` - retrieval only, used by the eval harness. **Gated to
+  `ENVIRONMENT=development`** via a deploy-time var, so it returns 404 in
+  production and exists only on a local dev Worker.
+
+CORS is restricted to `https://mux-lang.dev` (production) and
+`http://localhost:3000` (development) via `ALLOWED_ORIGIN` in `wrangler.toml`.
+The top-level `[vars]` default to the production (locked-down) posture, so a
+bare `wrangler deploy` never accidentally exposes the dev endpoint; opening it
+requires an explicit `--env development`.
+
+## Local development
+
+```bash
+npm install
+npm run dev          # wrangler dev --env development
+```
+
+`AI` and `VECTORIZE` have no local emulation. `npm run dev` works for serving
+the Worker, but anything that hits Vectorize/Workers AI (including the eval
+harness and `/api/search`) needs `--remote` so the bindings reach the real
+services:
+
+```bash
+npx wrangler dev --env development --remote
+```
+
+Point the website at a local Worker during frontend development:
+
+```bash
+cd ../../mux-website
+MUX_AI_API_URL=http://localhost:8787 npm start
+```
+
+## Deploying
+
+Deploys are manual and local only - no CI secrets, no GitHub Actions. Authenticate
+once with `wrangler login`, then:
+
+```bash
+npm run deploy       # wrangler deploy --env production -> mux-ai.corniedj.workers.dev
+```
+
+## Maintenance runbook (manual deploy - nothing is automated)
+
+There are three independent kinds of change. Do the steps that match what you
+touched. The eval steps need a local dev Worker running with `--remote`:
+
+```bash
+# Terminal 1 (leave running for any eval):
+cd workers/mux-ai && npx wrangler dev --env development --remote
+```
+
+### A. Docs changed (`mux-website/docs/**`)
+
+The chat answers from the Vectorize index, not the doc files, so doc edits do
+not take effect until you re-index. The Worker itself does **not** need
+redeploying for docs-only changes.
+
+```bash
+# 1. Re-embed + upsert + delete orphans + update out/manifest.json
+cd tools/docs-indexer && source .env && npm run index
+
+# 2. Verify retrieval is still calibrated (Terminal 2)
+cd tools/retrieval-test && npm run eval && npm run error-eval
+```
+
+3. If the **retrieval eval** fails on a threshold/margin, the score distribution
+   shifted. Recalibrate: look at where on-topic chunks now land versus the
+   highest off-topic leak, set `MIN_SCORE` (in `workers/mux-ai/src/index.ts`)
+   into the gap, adjust `MIN_HEALTHY_SCORE` (in `tools/retrieval-test/src/run.ts`)
+   to sit just above the floor, `npm run deploy` the Worker, and re-run the evals
+   until green.
+
+4. If the **error eval** fails because the right doc is not cited, the docs may
+   have a real gap - add the missing content to the doc, re-index, re-run. Do
+   not paper over it.
+
+### B. Worker code changed (`workers/mux-ai/src/**`)
+
+```bash
+cd workers/mux-ai && npm run typecheck && npm run deploy
+# then re-run both evals from Terminal 2 to confirm no regression
+```
+
+### C. Website frontend changed (`mux-website/src/**`)
+
+```bash
+cd mux-website && npm run typecheck && npm run lint && npm run build
+# then deploy the website by the usual manual process
+```
+
+The chat widget reads the Worker URL from `customFields.aiApiUrl` in
+`docusaurus.config.ts`, defaulting to the production Worker.

--- a/workers/mux-ai/package-lock.json
+++ b/workers/mux-ai/package-lock.json
@@ -1,0 +1,1528 @@
+{
+  "name": "mux-ai",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mux-ai",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20240909.0",
+        "typescript": "~5.6.2",
+        "wrangler": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260623.1.tgz",
+      "integrity": "sha512-MvDoIsRTsUJRzAl1/4hDXL839piyyjCeYatBHWgMc12Go7nHxkgbRih+1GJImEiKACSentu410bOupcutqFbpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260623.1.tgz",
+      "integrity": "sha512-sNqHQvHPMOj5/BJOadtEZekRPSG5qQ0/ulC30ZRHRLnmx6tj5O4Wb3Nf0oznnI0pmjXhbv6b7+TOpDkaFMjbBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260623.1.tgz",
+      "integrity": "sha512-XYTWqTlZlCXqG+Po6awjXtlxw73hb3C39B/PP0sb4H9NI3V0eynq8Q7rXNe7DHJs2pWRfDJihQzpayQvpwf5wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260623.1.tgz",
+      "integrity": "sha512-PC5UDKA8oQB3Gek/Y+ysovdHNjp55CihOQZd7F9xPwpkv9qTBB0mhyHnfoG2YHtW1bb9CNhuwiThaNxegpE4mg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260623.1.tgz",
+      "integrity": "sha512-OTHLCVYyN0pEfrajpjjnrGg5zA1GDnpNYmMz3x2ESFtH/oXRODsUQBllP7oJpJvMURF3rXSYwAhMojaftGry8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260623.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260623.1.tgz",
+      "integrity": "sha512-J/0POl0HeLepbwDE5Yx5c7jQrHFkvCEFu3TS+TQsDDlg/vTs5og7wdGP6eNGXOAntgWUrjcvvKTmVLTP7OrnAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260623.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260623.0.tgz",
+      "integrity": "sha512-p2YTeH01jMiMOjO4v9hb/+GJndja5LCxecGOWCaT9F414PRXgdddLDsK6MnqhGBB5tlU/WoBYIG1XZte5pQzOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260623.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260623.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260623.1.tgz",
+      "integrity": "sha512-9SJsdTSsehhqc26TUJIzyi1XgyYeqFym4hinZnWoAP1BkhEoMQ5Ygz7Xw9T+2ecU+y409JBEScBgWTdZ06mBrg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260623.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260623.1",
+        "@cloudflare/workerd-linux-64": "1.20260623.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260623.1",
+        "@cloudflare/workerd-windows-64": "1.20260623.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.104.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.104.0.tgz",
+      "integrity": "sha512-xCfbg2Oj93Bc7EMryFaSeRGDgV96dzrWoaK5q2q5XLEvumO4mysNP/1MDue0GUozEJAI6Z6vrGyYPLmfET/0sg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260623.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260623.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260623.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/workers/mux-ai/package.json
+++ b/workers/mux-ai/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mux-ai",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev --env development",
+    "deploy": "wrangler deploy --env production",
+    "deploy:dev": "wrangler deploy --env development",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240909.0",
+    "typescript": "~5.6.2",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/workers/mux-ai/src/index.ts
+++ b/workers/mux-ai/src/index.ts
@@ -116,18 +116,25 @@ function sweepExpired(now: number): void {
   }
 }
 
-function checkRateLimit(request: Request): boolean {
-  const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+function clientIp(request: Request): string {
+  return request.headers.get('CF-Connecting-IP') ?? 'unknown';
+}
+
+// Read-only cooldown check; does not record the request. Recording is deferred
+// to markRequest() so a request rejected by validation (bad JSON, oversized)
+// never burns the caller's cooldown, and only requests that actually reach the
+// AI calls consume a slot.
+function isWithinCooldown(ip: string): boolean {
   const now = Date.now();
   if (lastRequestByIp.size > RATE_LIMIT_MAP_CAP) {
     sweepExpired(now);
   }
   const last = lastRequestByIp.get(ip) ?? 0;
-  if (now - last < RATE_LIMIT_MS) {
-    return false;
-  }
-  lastRequestByIp.set(ip, now);
-  return true;
+  return now - last < RATE_LIMIT_MS;
+}
+
+function markRequest(ip: string): void {
+  lastRequestByIp.set(ip, Date.now());
 }
 
 async function embedQuery(query: string, env: Env): Promise<number[]> {
@@ -233,7 +240,8 @@ function parseChatRequest(body: unknown): ChatRequest | null {
 async function handleChat(request: Request, env: Env): Promise<Response> {
   const start = Date.now();
 
-  if (!checkRateLimit(request)) {
+  const ip = clientIp(request);
+  if (isWithinCooldown(ip)) {
     log({ event: 'rate_limit' });
     return jsonResponse(
       {
@@ -284,6 +292,9 @@ async function handleChat(request: Request, env: Env): Promise<Response> {
     );
   }
   const lastUserMessage = chatRequest.messages[lastUserIndex];
+
+  // Request is valid and about to hit the AI calls; consume the cooldown slot now.
+  markRequest(ip);
 
   log({ event: 'chat_request', turn_count: chatRequest.messages.length });
 

--- a/workers/mux-ai/src/index.ts
+++ b/workers/mux-ai/src/index.ts
@@ -1,0 +1,434 @@
+import { SYSTEM_PROMPT, NO_ANSWER_RESPONSE } from './prompts';
+import { log } from './logger';
+
+export interface Env {
+  AI: Ai;
+  VECTORIZE: VectorizeIndex;
+  ALLOWED_ORIGIN: string;
+  // Deploy-time only (set in wrangler.toml, never request-derived). Gates the
+  // dev-only /api/search endpoint; production deploys set this to "production".
+  ENVIRONMENT: string;
+}
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatSource {
+  title: string;
+  path: string;
+}
+
+export interface ChatRequest {
+  messages: ChatMessage[];
+}
+
+export type ErrorCode = 'RATE_LIMIT' | 'MODEL_UNAVAILABLE';
+
+export interface ChatResponse {
+  message?: string;
+  sources?: ChatSource[];
+  error?: string;
+  errorCode?: ErrorCode;
+}
+
+export interface SearchResult {
+  title: string;
+  path: string;
+  section: string;
+  heading: string | null;
+  text: string;
+  score: number;
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+}
+
+// Must stay on the exact same model + version the docs-indexer uses at index
+// time (tools/docs-indexer/src/embed.ts); query and passage vectors only share
+// a space if both are produced by the same model.
+const EMBEDDING_MODEL = '@cf/baai/bge-base-en-v1.5';
+// bge-base-en-v1.5 is an asymmetric retrieval model: queries are prefixed with
+// this instruction, passages are embedded raw (see the indexer). Keeping them
+// asymmetric separates query/passage vectors and improves ranking.
+const QUERY_INSTRUCTION = 'Represent this sentence for searching relevant passages: ';
+const GENERATION_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
+const TOP_K = 5;
+// Number of recent user turns combined into the retrieval query so contextual
+// follow-ups ("show me an example") inherit the topic of earlier turns. Only
+// affects what is embedded for search; the generation prompt still answers the
+// single latest message.
+const RETRIEVAL_HISTORY_TURNS = 3;
+// Maximum prior messages (excluding the current question) sent to the
+// generation model. Bounds per-call token cost so a long conversation does not
+// grow neuron consumption turn over turn; recent turns carry the conversational
+// context, older ones add cost with little value since the retrieved excerpts
+// dominate the prompt. Enforced server-side so a client cannot bypass it.
+const GENERATION_HISTORY_LIMIT = 6;
+// Maximum characters per message. Message count is already bounded by the
+// retrieval/generation history slices, so size is the only remaining cost
+// lever: a single oversized message would inflate the embedding/generation
+// call. Generous for a question or a pasted compiler error; not a blob.
+const MAX_CONTENT_CHARS = 2000;
+// Minimum cosine similarity for a chunk to be considered relevant. There is a
+// consistent gap between on-topic chunk scores and the highest off-topic leak;
+// this floor sits in that gap. The exact value depends on the embedding model,
+// the query instruction prefix (see QUERY_INSTRUCTION), and the chunking, so it
+// must be re-checked whenever any of those change. The retrieval-test harness
+// asserts both the positive margin and off-topic rejection, so a stale value
+// fails `npm run eval` rather than silently shifting recall.
+const MIN_SCORE = 0.61;
+// Minimum milliseconds between requests from the same IP.
+const RATE_LIMIT_MS = 2000;
+// When the cooldown map grows past this, sweep out expired entries. Bounds
+// memory for one-shot IPs that never return, without paying a sweep per request.
+const RATE_LIMIT_MAP_CAP = 10000;
+
+// Per-isolate cooldown map. Resets on isolate eviction, which is acceptable —
+// the goal is basic abuse prevention, not perfect rate limiting across all PoPs.
+const lastRequestByIp = new Map<string, number>();
+
+function corsHeaders(env: Env): HeadersInit {
+  if (!env.ALLOWED_ORIGIN) {
+    throw new Error('ALLOWED_ORIGIN is not configured for this environment');
+  }
+  return {
+    'Access-Control-Allow-Origin': env.ALLOWED_ORIGIN,
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+}
+
+function jsonResponse(body: unknown, env: Env, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders(env) },
+  });
+}
+
+function sweepExpired(now: number): void {
+  for (const [ip, ts] of lastRequestByIp) {
+    if (now - ts >= RATE_LIMIT_MS) {
+      lastRequestByIp.delete(ip);
+    }
+  }
+}
+
+function checkRateLimit(request: Request): boolean {
+  const ip = request.headers.get('CF-Connecting-IP') ?? 'unknown';
+  const now = Date.now();
+  if (lastRequestByIp.size > RATE_LIMIT_MAP_CAP) {
+    sweepExpired(now);
+  }
+  const last = lastRequestByIp.get(ip) ?? 0;
+  if (now - last < RATE_LIMIT_MS) {
+    return false;
+  }
+  lastRequestByIp.set(ip, now);
+  return true;
+}
+
+async function embedQuery(query: string, env: Env): Promise<number[]> {
+  // The workers-types union includes an async variant; cast to the sync shape
+  // since we never pass stream/async options to this model.
+  const result = (await env.AI.run(EMBEDDING_MODEL, {
+    text: [`${QUERY_INSTRUCTION}${query}`],
+  })) as {
+    data?: number[][];
+  };
+  if (!result.data?.[0]) {
+    throw new Error('Embedding model returned no vector data');
+  }
+  return result.data[0];
+}
+
+async function retrieveChunks(query: string, env: Env): Promise<SearchResult[]> {
+  const vector = await embedQuery(query, env);
+  const queryResult = await env.VECTORIZE.query(vector, {
+    topK: TOP_K,
+    returnMetadata: 'all',
+  });
+
+  return queryResult.matches
+    .filter((match) => match.score >= MIN_SCORE)
+    .map((match) => {
+      const meta = match.metadata as Record<string, unknown> | undefined;
+      return {
+        title: typeof meta?.title === 'string' ? meta.title : '',
+        path: typeof meta?.path === 'string' ? meta.path : '',
+        section: typeof meta?.section === 'string' ? meta.section : '',
+        heading: typeof meta?.heading === 'string' ? meta.heading : null,
+        text: typeof meta?.text === 'string' ? meta.text : '',
+        score: match.score,
+      };
+    });
+}
+
+function deduplicateSources(chunks: SearchResult[]): ChatSource[] {
+  const seen = new Set<string>();
+  const sources: ChatSource[] = [];
+  for (const chunk of chunks) {
+    if (!seen.has(chunk.path)) {
+      seen.add(chunk.path);
+      sources.push({ title: chunk.title, path: chunk.path });
+    }
+  }
+  return sources;
+}
+
+function buildContextBlock(chunks: SearchResult[]): string {
+  return chunks
+    .map((chunk, i) => {
+      const heading = chunk.heading ? ` > ${chunk.heading}` : '';
+      return `[${i + 1}] ${chunk.title}${heading} (${chunk.path})\n${chunk.text}`;
+    })
+    .join('\n\n---\n\n');
+}
+
+function buildUserMessageWithContext(userContent: string, chunks: SearchResult[]): string {
+  const context = buildContextBlock(chunks);
+  return `Documentation excerpts:\n${context}\n\nQuestion: ${userContent}`;
+}
+
+function normalize(text: string): string {
+  return text.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+// True when the model declined to answer. Uses a normalized startsWith rather
+// than strict equality: models sometimes append a sentence or tweak punctuation,
+// and the refusal phrase is distinctive enough that a prefix match is safe.
+function isRefusal(message: string): boolean {
+  return normalize(message).startsWith(normalize(NO_ANSWER_RESPONSE));
+}
+
+function buildRetrievalQuery(messages: ChatMessage[]): string {
+  const userTurns = messages.filter((m) => m.role === 'user').map((m) => m.content);
+  // Newest first: if the combined text exceeds the embedding model's context
+  // window and is truncated, the most recent (most important) turn survives and
+  // older context is dropped instead.
+  const recent = userTurns.slice(-RETRIEVAL_HISTORY_TURNS).reverse();
+  return recent.join('\n\n');
+}
+
+function parseChatRequest(body: unknown): ChatRequest | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const b = body as Record<string, unknown>;
+  if (!Array.isArray(b.messages)) return null;
+  for (const msg of b.messages) {
+    if (
+      typeof msg !== 'object' ||
+      msg === null ||
+      ((msg as Record<string, unknown>).role !== 'user' &&
+        (msg as Record<string, unknown>).role !== 'assistant') ||
+      typeof (msg as Record<string, unknown>).content !== 'string'
+    ) {
+      return null;
+    }
+  }
+  return b as unknown as ChatRequest;
+}
+
+async function handleChat(request: Request, env: Env): Promise<Response> {
+  const start = Date.now();
+
+  if (!checkRateLimit(request)) {
+    log({ event: 'rate_limit' });
+    return jsonResponse(
+      {
+        error: 'Too many requests. Please wait a moment before sending another message.',
+        errorCode: 'RATE_LIMIT',
+      } satisfies ChatResponse,
+      env,
+      429,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' } satisfies ChatResponse, env, 400);
+  }
+
+  const chatRequest = parseChatRequest(body);
+  if (!chatRequest || chatRequest.messages.length === 0) {
+    return jsonResponse(
+      { error: 'messages must be a non-empty array of {role, content}' } satisfies ChatResponse,
+      env,
+      400,
+    );
+  }
+
+  if (chatRequest.messages.some((m) => m.content.length > MAX_CONTENT_CHARS)) {
+    return jsonResponse(
+      { error: `Each message must be at most ${MAX_CONTENT_CHARS} characters.` } satisfies ChatResponse,
+      env,
+      400,
+    );
+  }
+
+  let lastUserIndex = -1;
+  for (let i = chatRequest.messages.length - 1; i >= 0; i--) {
+    if (chatRequest.messages[i].role === 'user') {
+      lastUserIndex = i;
+      break;
+    }
+  }
+  if (lastUserIndex === -1) {
+    return jsonResponse(
+      { error: 'At least one user message is required' } satisfies ChatResponse,
+      env,
+      400,
+    );
+  }
+  const lastUserMessage = chatRequest.messages[lastUserIndex];
+
+  log({ event: 'chat_request', turn_count: chatRequest.messages.length });
+
+  const retrievalQuery = buildRetrievalQuery(chatRequest.messages);
+
+  let chunks: SearchResult[];
+  try {
+    chunks = await retrieveChunks(retrievalQuery, env);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log({ event: 'retrieval_error', message });
+    return jsonResponse(
+      {
+        error: 'The AI assistant is temporarily unavailable. Please try again shortly.',
+        errorCode: 'MODEL_UNAVAILABLE',
+      } satisfies ChatResponse,
+      env,
+      503,
+    );
+  }
+
+  if (chunks.length === 0) {
+    log({ event: 'no_results', query_length: retrievalQuery.length });
+    return jsonResponse(
+      { message: NO_ANSWER_RESPONSE, sources: [] } satisfies ChatResponse,
+      env,
+    );
+  }
+
+  log({
+    event: 'retrieval_result',
+    chunk_count: chunks.length,
+    top_score: chunks[0].score,
+    query_length: retrievalQuery.length,
+  });
+
+  // Build the messages array for the generation model. Everything before the
+  // last user message is prior context (capped for bounded cost); that last user
+  // message is the one we inject the retrieved excerpts into below.
+  const priorMessages = chatRequest.messages.slice(0, lastUserIndex).slice(-GENERATION_HISTORY_LIMIT);
+  const augmentedUserContent = buildUserMessageWithContext(lastUserMessage.content, chunks);
+
+  const llmMessages = [
+    { role: 'system' as const, content: SYSTEM_PROMPT },
+    ...priorMessages.map((m) => ({ role: m.role as 'user' | 'assistant', content: m.content })),
+    { role: 'user' as const, content: augmentedUserContent },
+  ];
+
+  let generation: { response?: string };
+  try {
+    generation = (await env.AI.run(GENERATION_MODEL, {
+      messages: llmMessages,
+      max_tokens: 1024,
+    })) as { response?: string };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log({ event: 'generation_error', message });
+    return jsonResponse(
+      {
+        error: 'The AI assistant is temporarily unavailable. Please try again shortly.',
+        errorCode: 'MODEL_UNAVAILABLE',
+      } satisfies ChatResponse,
+      env,
+      503,
+    );
+  }
+
+  const message = generation.response?.trim() ?? '';
+  // Don't cite sources for a refusal: the retrieved chunks cleared the score
+  // floor but the model judged they don't actually answer the question, so
+  // showing them under an "I couldn't find that" message would be contradictory.
+  const sources = isRefusal(message) ? [] : deduplicateSources(chunks);
+  log({
+    event: 'chat_response',
+    latency_ms: Date.now() - start,
+    chunk_count: chunks.length,
+    source_count: sources.length,
+  });
+
+  return jsonResponse({ message, sources } satisfies ChatResponse, env);
+}
+
+async function handleSearch(request: Request, env: Env): Promise<Response> {
+  const start = Date.now();
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' }, env, 400);
+  }
+
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    typeof (body as Record<string, unknown>).query !== 'string'
+  ) {
+    return jsonResponse({ error: 'Missing required field: query' }, env, 400);
+  }
+
+  const query = ((body as Record<string, unknown>).query as string).trim();
+  if (!query) {
+    return jsonResponse({ error: 'query must not be empty' }, env, 400);
+  }
+
+  log({ event: 'search_request', query_length: query.length });
+
+  const results = await retrieveChunks(query, env);
+
+  log({ event: 'search_response', latency_ms: Date.now() - start, chunk_count: results.length });
+
+  return jsonResponse({ results } satisfies SearchResponse, env);
+}
+
+function handleHealth(env: Env): Response {
+  return jsonResponse({ status: 'ok' }, env);
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers: corsHeaders(env) });
+    }
+
+    const url = new URL(request.url);
+
+    if (url.pathname === '/api/chat/health' && request.method === 'GET') {
+      return handleHealth(env);
+    }
+
+    if (url.pathname === '/api/chat' && request.method === 'POST') {
+      return handleChat(request, env);
+    }
+
+    // Dev-only retrieval endpoint for the eval harness. ENVIRONMENT is a
+    // deploy-time var, so in production this falls through to 404 and there is
+    // no request-controllable way to reach handleSearch.
+    if (
+      url.pathname === '/api/search' &&
+      request.method === 'POST' &&
+      env.ENVIRONMENT === 'development'
+    ) {
+      return handleSearch(request, env);
+    }
+
+    return jsonResponse({ error: 'NOT_FOUND' }, env, 404);
+  },
+};

--- a/workers/mux-ai/src/index.ts
+++ b/workers/mux-ai/src/index.ts
@@ -237,6 +237,34 @@ function parseChatRequest(body: unknown): ChatRequest | null {
   return b as unknown as ChatRequest;
 }
 
+type ValidatedChat =
+  | { ok: true; messages: ChatMessage[]; lastUserIndex: number }
+  | { ok: false; error: string };
+
+// Parse and validate a chat request body: shape, per-message size, and the
+// presence of a user message. Extracted from handleChat to keep that handler's
+// branching (and cognitive complexity) low.
+function validateChatBody(body: unknown): ValidatedChat {
+  const chatRequest = parseChatRequest(body);
+  if (!chatRequest || chatRequest.messages.length === 0) {
+    return { ok: false, error: 'messages must be a non-empty array of {role, content}' };
+  }
+  if (chatRequest.messages.some((m) => m.content.length > MAX_CONTENT_CHARS)) {
+    return { ok: false, error: `Each message must be at most ${MAX_CONTENT_CHARS} characters.` };
+  }
+  let lastUserIndex = -1;
+  for (let i = chatRequest.messages.length - 1; i >= 0; i--) {
+    if (chatRequest.messages[i].role === 'user') {
+      lastUserIndex = i;
+      break;
+    }
+  }
+  if (lastUserIndex === -1) {
+    return { ok: false, error: 'At least one user message is required' };
+  }
+  return { ok: true, messages: chatRequest.messages, lastUserIndex };
+}
+
 async function handleChat(request: Request, env: Env): Promise<Response> {
   const start = Date.now();
 
@@ -260,45 +288,19 @@ async function handleChat(request: Request, env: Env): Promise<Response> {
     return jsonResponse({ error: 'Invalid JSON body' } satisfies ChatResponse, env, 400);
   }
 
-  const chatRequest = parseChatRequest(body);
-  if (!chatRequest || chatRequest.messages.length === 0) {
-    return jsonResponse(
-      { error: 'messages must be a non-empty array of {role, content}' } satisfies ChatResponse,
-      env,
-      400,
-    );
+  const validated = validateChatBody(body);
+  if (!validated.ok) {
+    return jsonResponse({ error: validated.error } satisfies ChatResponse, env, 400);
   }
-
-  if (chatRequest.messages.some((m) => m.content.length > MAX_CONTENT_CHARS)) {
-    return jsonResponse(
-      { error: `Each message must be at most ${MAX_CONTENT_CHARS} characters.` } satisfies ChatResponse,
-      env,
-      400,
-    );
-  }
-
-  let lastUserIndex = -1;
-  for (let i = chatRequest.messages.length - 1; i >= 0; i--) {
-    if (chatRequest.messages[i].role === 'user') {
-      lastUserIndex = i;
-      break;
-    }
-  }
-  if (lastUserIndex === -1) {
-    return jsonResponse(
-      { error: 'At least one user message is required' } satisfies ChatResponse,
-      env,
-      400,
-    );
-  }
-  const lastUserMessage = chatRequest.messages[lastUserIndex];
+  const { messages, lastUserIndex } = validated;
+  const lastUserMessage = messages[lastUserIndex];
 
   // Request is valid and about to hit the AI calls; consume the cooldown slot now.
   markRequest(ip);
 
-  log({ event: 'chat_request', turn_count: chatRequest.messages.length });
+  log({ event: 'chat_request', turn_count: messages.length });
 
-  const retrievalQuery = buildRetrievalQuery(chatRequest.messages);
+  const retrievalQuery = buildRetrievalQuery(messages);
 
   let chunks: SearchResult[];
   try {
@@ -334,7 +336,7 @@ async function handleChat(request: Request, env: Env): Promise<Response> {
   // Build the messages array for the generation model. Everything before the
   // last user message is prior context (capped for bounded cost); that last user
   // message is the one we inject the retrieved excerpts into below.
-  const priorMessages = chatRequest.messages.slice(0, lastUserIndex).slice(-GENERATION_HISTORY_LIMIT);
+  const priorMessages = messages.slice(0, lastUserIndex).slice(-GENERATION_HISTORY_LIMIT);
   const augmentedUserContent = buildUserMessageWithContext(lastUserMessage.content, chunks);
 
   const llmMessages = [

--- a/workers/mux-ai/src/logger.ts
+++ b/workers/mux-ai/src/logger.ts
@@ -1,0 +1,20 @@
+/**
+ * Structured JSON logging for wrangler tail and the Cloudflare dashboard.
+ * Each call emits one JSON line to stdout. No PII: IPs are never logged,
+ * query text is never logged — only derived metrics (length, count).
+ */
+
+type LogEvent =
+  | { event: 'chat_request'; turn_count: number }
+  | { event: 'rate_limit' }
+  | { event: 'retrieval_result'; chunk_count: number; top_score: number; query_length: number }
+  | { event: 'no_results'; query_length: number }
+  | { event: 'retrieval_error'; message: string }
+  | { event: 'generation_error'; message: string }
+  | { event: 'chat_response'; latency_ms: number; chunk_count: number; source_count: number }
+  | { event: 'search_request'; query_length: number }
+  | { event: 'search_response'; latency_ms: number; chunk_count: number };
+
+export function log(entry: LogEvent): void {
+  console.log(JSON.stringify({ ts: new Date().toISOString(), ...entry }));
+}

--- a/workers/mux-ai/src/prompts.ts
+++ b/workers/mux-ai/src/prompts.ts
@@ -1,0 +1,25 @@
+// The exact sentence the model is told to emit when the excerpts don't contain
+// the answer. Exported so handleChat can detect a refusal and strip sources
+// from it; the system prompt is built from this constant so the instruction and
+// the detector can never drift apart.
+export const NO_ANSWER_RESPONSE =
+  "I couldn't find that information in the current Mux documentation.";
+
+export const SYSTEM_PROMPT = `You are the official Mux AI assistant. Mux is a statically-typed, reference-counted programming language with a clean, modern syntax.
+
+Answer questions only using the documentation excerpts provided in the user message. Do not invent syntax, features, or behaviors not present in the excerpts.
+
+If the answer is not present in the provided excerpts, respond with exactly:
+"${NO_ANSWER_RESPONSE}"
+This refusal rule applies to questions about Mux language features. It does NOT apply to compiler errors (see below).
+
+When showing code examples, use Mux syntax as demonstrated in the excerpts. Keep answers concise and direct.
+
+## Handling compiler errors
+
+When the user pastes compiler output (lines starting with "error:", "--> file:", or "= help:"):
+1. Always explain the error, even if the documentation excerpts do not directly cover it. Never respond with the refusal sentence for a compiler error.
+2. Identify the error category (lexer, parser, or semantic) from context.
+3. Explain in plain language what the error means and what likely caused it, using the error text and any "= help:" line.
+4. Suggest a concrete fix. Ground the fix in the documentation excerpts and do not invent syntax or features that are not shown in them.
+5. Cite the relevant documentation section when one applies.`;

--- a/workers/mux-ai/tsconfig.json
+++ b/workers/mux-ai/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021"],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/mux-ai/wrangler.toml
+++ b/workers/mux-ai/wrangler.toml
@@ -1,0 +1,41 @@
+name = "mux-ai"
+main = "src/index.ts"
+compatibility_date = "2024-09-23"
+
+[ai]
+binding = "AI"
+
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = "mux-docs"
+
+# Fail-safe defaults for a bare `wrangler deploy` (no --env): lock down to the
+# production posture so the dev-only /api/search endpoint is never accidentally
+# exposed on the real URL. Opening it requires an explicit `--env development`
+# (see `npm run dev`).
+[vars]
+ENVIRONMENT = "production"
+ALLOWED_ORIGIN = "https://mux-lang.dev"
+
+[env.production]
+# Override the default "<name>-<env>" naming so deploys target the "mux-ai"
+# Worker created in the dashboard rather than creating "mux-ai-production".
+name = "mux-ai"
+vars = { ENVIRONMENT = "production", ALLOWED_ORIGIN = "https://mux-lang.dev" }
+
+[env.production.ai]
+binding = "AI"
+
+[[env.production.vectorize]]
+binding = "VECTORIZE"
+index_name = "mux-docs"
+
+[env.development]
+vars = { ENVIRONMENT = "development", ALLOWED_ORIGIN = "http://localhost:3000" }
+
+[env.development.ai]
+binding = "AI"
+
+[[env.development.vectorize]]
+binding = "VECTORIZE"
+index_name = "mux-docs"


### PR DESCRIPTION
## Summary

Adds an AI documentation assistant to the Mux website: an in-docs chat widget that answers questions about Mux, generates examples, and explains compiler errors, grounded in the official docs via retrieval-augmented generation (RAG). It runs entirely on Cloudflare's free tier (Workers AI + Vectorize), separate from the billed `mux-lang-api` Fly.io service, and degrades gracefully when quota is exhausted.

## What's added

- **`workers/mux-ai/`** - Cloudflare Worker. `POST /api/chat` embeds the query (with recent turns for context), retrieves the top doc chunks from Vectorize above a calibrated score floor, and generates a grounded answer with citations via Llama 3.3 70B. Includes per-IP rate limiting, per-message size limits, bounded conversation history, structured JSON logging, and a dev-only `POST /api/search` used by the eval harness.
- **`tools/docs-indexer/`** - embeds `mux-website/docs/` into the `mux-docs` Vectorize index (`npm run index`). Chunks fit the embedding model's context window, and re-indexing is self-healing (manifest-diff deletes orphaned vectors).
- **`tools/retrieval-test/`** - eval harness: `npm run eval` (retrieval hit-rate + score-margin + off-topic rejection) and `npm run error-eval` (error-explainer grounding, built from `docs/error-corpus/`).
- **`mux-website/src/components/Chat/`** - the chat widget (button + drawer), mounted site-wide via `src/theme/Root.tsx`. Assistant answers render markdown through Docusaurus' own `CodeBlock` (highlighted, XSS-safe), with clickable source citations.

## How it works

Question -> embed (query-instruction-prefixed, asymmetric to passages) -> Vectorize top-k above `MIN_SCORE` -> assemble prompt with the retrieved excerpts -> Llama 3.3 70B -> `{ message, sources }`. The system prompt refuses to answer from outside the docs (except for explaining compiler errors, which it always attempts).

## Deployment & maintenance

Deploys are **manual** (`wrangler deploy`, no CI secrets). The full runbook is in `workers/mux-ai/README.md` - notably: editing docs has no effect until you re-index, and re-indexing can require recalibrating `MIN_SCORE` (the eval harness guards this).

## Testing

- Retrieval eval: **8/8** (5 topic questions clear the score margin; 3 off-topic queries correctly return nothing).
- Error-explainer eval: **19/19** (every fixture explained and grounded in the right doc).
- Worker + website typecheck/lint clean; website production build succeeds.

## Deliberate trade-offs

- `MIN_SCORE` is a constant that must be re-checked after a re-index (enforced by the eval, not silent).
- Rate limiting is per-isolate basic abuse prevention, not a global limiter.
- The re-index manifest is local-only (documented); no response streaming. All appropriate to the free-tier mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
