### PR TITLE
[TEST DO NOT MERGE] docs: clarify optional err arm in match example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ func main() returns void {
         ok(value) {
             print("Result: " + value.to_string())
         }
-        // The err arm is optional - the compiler falls through silently
-        // if it's omitted, so only add it when you need to handle errors.
+        // Note: shown here for brevity. See the Language Guide for the
+        // full exhaustiveness rules around result and optional matches.
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -151,9 +151,8 @@ func main() returns void {
         ok(value) {
             print("Result: " + value.to_string())
         }
-        err(error) {
-            print("Error: " + error)
-        }
+        // The err arm is optional - the compiler falls through silently
+        // if it's omitted, so only add it when you need to handle errors.
     }
 }
 ```


### PR DESCRIPTION
## Summary
- Updates the quick-start `match` example in the README to show that the `err` arm can be skipped when the caller only cares about the happy path.

## Test plan
- [ ] Visual check of the rendered README example