### PR TITLE
ci: build/test against mux-runtime main source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.cache/mux-lang/runtime
-          key: ${{ runner.os }}-muxrt-${{ steps.runtime_sha.outputs.sha }}
+          key: ${{ runner.os }}-muxrt-1.93.1-${{ steps.runtime_sha.outputs.sha }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,17 @@ jobs:
       MUX_RUNTIME_SRC: ${{ github.workspace }}/mux-runtime
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          repository: muxlang/mux-runtime
+          ref: main
+          path: mux-runtime
+      - id: runtime_sha
+        run: echo "sha=$(git -C mux-runtime rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/mux-lang/runtime
+          key: ${{ runner.os }}-muxrt-${{ steps.runtime_sha.outputs.sha }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
@@ -65,7 +76,6 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             ~/.cargo/bin
-            ~/.cache/mux-lang
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-


### PR DESCRIPTION
Closes #227

## Problem

mux-compiler CI resolved `mux-runtime` from the crates.io pin, so `MUX_RUNTIME_SRC` (already set in `build.yml` to `${{ github.workspace }}/mux-runtime`) pointed at a directory that never existed and runtime source resolution fell through to the registry. Coupled runtime changes could not be exercised without a crates.io publish plus a pin bump.

## Change

In the `rust_checks` job (the one running `./scripts/run-checks.sh` and `cargo llvm-cov`, which already sets `MUX_RUNTIME_SRC`):

- Add a second `actions/checkout@v4` right after the primary checkout that clones `muxlang/mux-runtime` (`ref: main`) into `mux-runtime`.
- Capture the runtime commit SHA and give the runtime build its own `actions/cache` under `~/.cache/mux-lang/runtime`, keyed on that SHA with no loose `restore-keys`, so a new runtime `main` commit forces a rebuild instead of reusing a stale cached lib.
- Remove `~/.cache/mux-lang` from the broad cargo cache so it no longer masks runtime source changes (cargo registry/git/bin entries kept).

`release.yml` is intentionally left untouched: releases use the pinned, published runtime. The `mux-runtime` version pin and `Cargo.toml`/`Cargo.lock` are unchanged.

## Sequencing note

Runtime `main` must already contain any symbols a coupled compiler change depends on. Land the runtime change on `main` first (or point this checkout at the coupled runtime branch), otherwise the compiler build here will fail to resolve the new symbols.

## Scope note

`integration_checks` also runs `run-checks.sh`, but it does so inside a Docker container via `docker compose run`, where host-side checkout/cache steps and `MUX_RUNTIME_SRC` do not apply; wiring runtime source into that container would require docker-compose changes outside `build.yml`, so it is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHzxfKSRxtRacJnuMnoPA1