### PR TITLE
fix(ci): exclude checked-out mux-runtime from the compiler workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 members = ["mux-compiler"]
 default-members = ["mux-compiler"]
+# CI checks out muxlang/mux-runtime into ./mux-runtime so the compiler can build
+# it from source (see .github/workflows/build.yml). Exclude it so Cargo does not
+# try to attach that standalone crate to this workspace. Harmless when the
+# directory is absent (local sibling checkouts, normal builds).
+exclude = ["mux-runtime"]
 resolver = "2"
 
 [profile.release]


### PR DESCRIPTION
## Problem

#228 made CI check out `muxlang/mux-runtime` into `./mux-runtime` (inside `$GITHUB_WORKSPACE`) so the compiler builds the runtime from source. But that path sits inside this repo's Cargo **workspace**, so when the compiler shells out to `cargo build` the runtime, Cargo attaches it to the workspace and fails:

```
error: current package believes it's in a workspace when it's not:
current:   .../mux-compiler/mux-runtime/Cargo.toml
workspace: .../mux-compiler/Cargo.toml
```

This broke the `executable_integration` snapshots on `main` (every `.mux` test captured the runtime build error instead of program output). It didn't surface in the PR because the heavy job couldn't run there, and locally the runtime is a sibling *above* the workspace, not nested inside it.

## Fix

Add `mux-runtime` to `workspace.exclude` in the root `Cargo.toml` - exactly what Cargo's error suggests. Cargo then treats the checked-out runtime as its own standalone crate.

Verified in a scratch worktree that reproduces the CI layout:
- nested runtime `cargo metadata` **fails** before the fix, **succeeds** after;
- the compiler workspace still resolves with the exclude present;
- the exclude is a no-op when `./mux-runtime` is absent (local/normal builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHzxfKSRxtRacJnuMnoPA1