### PR TITLE
Updates Runtime Panics (#225)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # The dev container mounts the repo at /workspace and sets
+      # MUX_RUNTIME_SRC=/workspace/mux-runtime, so the compiler builds the
+      # runtime from source. Check it out here (root Cargo.toml excludes it
+      # from the workspace) instead of falling back to the crates.io pin.
+      - uses: actions/checkout@v4
+        with:
+          repository: muxlang/mux-runtime
+          ref: main
+          path: mux-runtime
       - name: Docker info
         run: docker compose version
       - name: Service-backed checks

--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,9 @@ target
 *.ll
 test_scripts/*
 !test_scripts/*.mux
-test_scripts/error_cases/*.mux
-!test_scripts/error_cases/*.mux
+!test_scripts/error_cases/
 test_scripts/error_cases/*
+!test_scripts/error_cases/*.mux
 
 # JavaScript / Node (mux-website, workers/, tools/). Global rule so any future
 # JS subdir is covered automatically rather than relying on a per-dir .gitignore.

--- a/mux-compiler/src/codegen/expressions.rs
+++ b/mux-compiler/src/codegen/expressions.rs
@@ -2989,14 +2989,14 @@ impl<'a> CodeGenerator<'a> {
                     .builder
                     .build_call(
                         self.runtime_function("mux_list_length")
-                            .expect("mux_list_length must be declared in runtime"),
+                            .ok_or("mux_list_length not found")?,
                         &[raw_list_ptr.into()],
                         "index_len",
                     )
                     .map_err(|e| e.to_string())?
                     .try_as_basic_value()
                     .basic()
-                    .expect("mux_list_length should return a basic value");
+                    .ok_or("mux_list_length should return a basic value")?;
 
                 // call mux_list_get_value (returns direct value or null)
                 let raw_result = self
@@ -3023,10 +3023,12 @@ impl<'a> CodeGenerator<'a> {
                     .build_call(free_list, &[raw_list_ptr.into()], "free_list")
                     .map_err(|e| e.to_string())?;
 
-                // Bounds-check the result pointer
+                // Bounds-check the result pointer. Report the user's original
+                // index (pre-normalization) so `values[-5]` reads "-5", not the
+                // wrapped value.
                 self.check_list_bounds(
                     result_ptr,
-                    normalized_index,
+                    index_val,
                     list_length,
                     Some(index.span()),
                     "index",
@@ -3765,14 +3767,14 @@ impl<'a> CodeGenerator<'a> {
             .builder
             .build_call(
                 self.runtime_function("mux_list_length")
-                    .expect("mux_list_length must be declared in runtime"),
+                    .ok_or("mux_list_length not found")?,
                 &[list.into()],
                 &format!("{}_len", block_prefix),
             )
             .map_err(|e| e.to_string())?
             .try_as_basic_value()
             .basic()
-            .expect("mux_list_length should return a basic value");
+            .ok_or("mux_list_length should return a basic value")?;
 
         let next = self
             .builder
@@ -3787,14 +3789,9 @@ impl<'a> CodeGenerator<'a> {
             .basic()
             .expect("mux_list_get_value should return a basic value");
 
-        // Bounds check: a null result means the index was out of range.
-        self.check_list_bounds(
-            next.into_pointer_value(),
-            normalized_index,
-            length,
-            span,
-            block_prefix,
-        )?;
+        // Bounds check: a null result means the index was out of range. Report
+        // the user's original index (pre-normalization).
+        self.check_list_bounds(next.into_pointer_value(), index, length, span, block_prefix)?;
 
         // Free the raw list.
         let free_list_fn = self

--- a/mux-compiler/src/codegen/expressions.rs
+++ b/mux-compiler/src/codegen/expressions.rs
@@ -18,8 +18,9 @@ use inkwell::values::{BasicMetadataValueEnum, BasicValueEnum, PointerValue};
 
 use crate::ast::{
     BinaryOp, ExpressionKind, ExpressionNode, FunctionNode, LiteralNode, Param, PrimitiveType,
-    StatementNode, TypeKind, TypeNode, UnaryOp,
+    Spanned, StatementNode, TypeKind, TypeNode, UnaryOp,
 };
+use crate::lexer::Span;
 use crate::semantics::{GenericContext, SymbolKind, Type};
 
 use super::CodeGenerator;
@@ -2982,6 +2983,21 @@ impl<'a> CodeGenerator<'a> {
                 // Normalize the index to handle negative wraparound
                 let normalized_index = self.normalize_list_index(index_val, raw_list_ptr)?;
 
+                // Capture the length for the out-of-bounds panic message
+                // while the raw list pointer is still alive.
+                let list_length = self
+                    .builder
+                    .build_call(
+                        self.runtime_function("mux_list_length")
+                            .expect("mux_list_length must be declared in runtime"),
+                        &[raw_list_ptr.into()],
+                        "index_len",
+                    )
+                    .map_err(|e| e.to_string())?
+                    .try_as_basic_value()
+                    .basic()
+                    .expect("mux_list_length should return a basic value");
+
                 // call mux_list_get_value (returns direct value or null)
                 let raw_result = self
                     .builder
@@ -3008,7 +3024,13 @@ impl<'a> CodeGenerator<'a> {
                     .map_err(|e| e.to_string())?;
 
                 // Bounds-check the result pointer
-                self.check_non_null_pointer(result_ptr, "List index out of bounds", "index")?;
+                self.check_list_bounds(
+                    result_ptr,
+                    normalized_index,
+                    list_length,
+                    Some(index.span()),
+                    "index",
+                )?;
 
                 // Use extract_value_from_ptr to properly extract based on type
                 let (extracted_val, _) =
@@ -3031,10 +3053,10 @@ impl<'a> CodeGenerator<'a> {
                     .expect("mux_value_get_map should return a basic value")
                     .into_pointer_value();
 
-                // map_get_or_panic handles the lookup, key-not-found error
+                // map_get_or_panic handles the lookup, key-not-found panic
                 // block, and Optional unwrap, then frees the raw map.
                 let value_ptr = self
-                    .map_get_or_panic(raw_map_ptr, index_val, "Key not found in map", "map")?
+                    .map_get_or_panic(raw_map_ptr, index_val, Some(index.span()), "map")?
                     .into_pointer_value();
 
                 // Use extract_value_from_ptr to properly extract based on type
@@ -3585,30 +3607,23 @@ impl<'a> CodeGenerator<'a> {
             .ok_or("mux_value_to_string should return a basic value".to_string())
     }
 
-    /// Emit a "print error message and exit(1); unreachable" terminator.
-    /// The current block is consumed and a new unreachable block follows.
-    fn emit_runtime_fatal(&mut self, message: &str, block_name: &str) -> Result<(), String> {
-        let _current_function = self
-            .builder
-            .get_insert_block()
-            .expect("Builder should have an insertion block")
-            .get_parent()
-            .ok_or("No current function")?;
-
+    /// Emit a unified runtime panic terminator: the message and an optional
+    /// `--> file:line:col` location go to stderr and the process exits with
+    /// code 1. The current block is consumed and left unreachable.
+    pub(super) fn emit_runtime_fatal(
+        &mut self,
+        message: &str,
+        span: Option<&Span>,
+        block_name: &str,
+    ) -> Result<(), String> {
         let error_msg = self
             .builder
             .build_global_string_ptr(message, &format!("{}_msg", block_name))
             .map_err(|e| e.to_string())?;
-        let error_str = self
-            .generate_runtime_call(
-                "mux_new_string_from_cstr",
-                &[error_msg.as_pointer_value().into()],
-            )
-            .expect("mux_new_string_from_cstr should always return a value");
-        self.generate_runtime_call("mux_print", &[error_str.into()]);
+        let loc = self.panic_location_arg(span, block_name)?;
         self.generate_runtime_call(
-            "exit",
-            &[self.context.i32_type().const_int(1, false).into()],
+            "mux_panic_cstr",
+            &[error_msg.as_pointer_value().into(), loc.into()],
         );
         self.builder
             .build_unreachable()
@@ -3616,16 +3631,41 @@ impl<'a> CodeGenerator<'a> {
         Ok(())
     }
 
+    /// Build the `file:line:col` location argument for the runtime panic
+    /// functions: a global string pointer, or null when no span is available.
+    pub(super) fn panic_location_arg(
+        &mut self,
+        span: Option<&Span>,
+        block_name: &str,
+    ) -> Result<BasicValueEnum<'a>, String> {
+        match span {
+            Some(span) => {
+                let loc = self.panic_location(span);
+                let global = self
+                    .builder
+                    .build_global_string_ptr(&loc, &format!("{}_loc", block_name))
+                    .map_err(|e| e.to_string())?;
+                Ok(global.as_pointer_value().into())
+            }
+            None => Ok(self
+                .context
+                .ptr_type(AddressSpace::default())
+                .const_null()
+                .into()),
+        }
+    }
+
     /// Look up `key` in the raw `map` and return the unwrapped value, freeing
-    /// the raw map pointer. If the key is missing, emits a fatal error block
-    /// and branches to a new "continue" block where the caller can continue.
+    /// the raw map pointer. If the key is missing, emits a key-not-found panic
+    /// block and branches to a new "continue" block where the caller can
+    /// continue.
     ///
     /// Returns the unwrapped value (`BasicValueEnum`).
     fn map_get_or_panic(
         &mut self,
         map: PointerValue<'a>,
         key: BasicValueEnum<'a>,
-        error_message: &str,
+        span: Option<&Span>,
         block_prefix: &str,
     ) -> Result<BasicValueEnum<'a>, String> {
         let boxed_key = self.box_value(key);
@@ -3676,9 +3716,13 @@ impl<'a> CodeGenerator<'a> {
             .build_conditional_branch(is_some, continue_bb, error_bb)
             .map_err(|e| e.to_string())?;
 
-        // Error block: print and exit
+        // Error block: panic with the missing key and source location
         self.builder.position_at_end(error_bb);
-        self.emit_runtime_fatal(error_message, &format!("{}_error", block_prefix))?;
+        let loc = self.panic_location_arg(span, &format!("{}_error", block_prefix))?;
+        self.generate_runtime_call("mux_panic_key_not_found", &[boxed_key.into(), loc.into()]);
+        self.builder
+            .build_unreachable()
+            .map_err(|e| e.to_string())?;
 
         // Continue block: free the raw map, then unwrap the optional
         self.builder.position_at_end(continue_bb);
@@ -3704,18 +3748,31 @@ impl<'a> CodeGenerator<'a> {
 
     /// Look up `index` in the raw `list` (after negative-index normalization)
     /// and return the value, freeing the raw list pointer. If the index is
-    /// out of bounds, emits a fatal error block and branches to a new
-    /// "continue" block.
+    /// out of bounds, emits an index-out-of-bounds panic block and branches
+    /// to a new "continue" block.
     ///
     /// Returns the unwrapped value (`BasicValueEnum`).
     fn list_get_or_panic(
         &mut self,
         list: PointerValue<'a>,
         index: BasicValueEnum<'a>,
-        error_message: &str,
+        span: Option<&Span>,
         block_prefix: &str,
     ) -> Result<BasicValueEnum<'a>, String> {
         let normalized_index = self.normalize_list_index(index, list)?;
+
+        let length = self
+            .builder
+            .build_call(
+                self.runtime_function("mux_list_length")
+                    .expect("mux_list_length must be declared in runtime"),
+                &[list.into()],
+                &format!("{}_len", block_prefix),
+            )
+            .map_err(|e| e.to_string())?
+            .try_as_basic_value()
+            .basic()
+            .expect("mux_list_length should return a basic value");
 
         let next = self
             .builder
@@ -3730,8 +3787,14 @@ impl<'a> CodeGenerator<'a> {
             .basic()
             .expect("mux_list_get_value should return a basic value");
 
-        // Bounds check: delegate to the shared null-pointer helper.
-        self.check_non_null_pointer(next.into_pointer_value(), error_message, block_prefix)?;
+        // Bounds check: a null result means the index was out of range.
+        self.check_list_bounds(
+            next.into_pointer_value(),
+            normalized_index,
+            length,
+            span,
+            block_prefix,
+        )?;
 
         // Free the raw list.
         let free_list_fn = self
@@ -3744,14 +3807,16 @@ impl<'a> CodeGenerator<'a> {
         Ok(next)
     }
 
-    /// If `ptr` is null, emit a fatal-error block with the given message
-    /// and position the builder at a new "continue" block. Used by list
-    /// index access to check out-of-bounds after a raw `mux_list_get_value`
-    /// call.
-    fn check_non_null_pointer(
+    /// If `ptr` is null (an out-of-bounds `mux_list_get_value` result), emit
+    /// an index-out-of-bounds panic block carrying the index, list length,
+    /// and source location, then position the builder at a new "continue"
+    /// block.
+    fn check_list_bounds(
         &mut self,
         ptr: inkwell::values::PointerValue<'a>,
-        error_message: &str,
+        index: BasicValueEnum<'a>,
+        length: BasicValueEnum<'a>,
+        span: Option<&Span>,
         block_prefix: &str,
     ) -> Result<(), String> {
         let is_null = self
@@ -3778,7 +3843,14 @@ impl<'a> CodeGenerator<'a> {
             .map_err(|e| e.to_string())?;
 
         self.builder.position_at_end(error_bb);
-        self.emit_runtime_fatal(error_message, &format!("{}_error", block_prefix))?;
+        let loc = self.panic_location_arg(span, &format!("{}_error", block_prefix))?;
+        self.generate_runtime_call(
+            "mux_panic_index_oob",
+            &[index.into(), length.into(), loc.into()],
+        );
+        self.builder
+            .build_unreachable()
+            .map_err(|e| e.to_string())?;
 
         self.builder.position_at_end(continue_bb);
         Ok(())
@@ -4111,7 +4183,7 @@ impl<'a> CodeGenerator<'a> {
                     self.list_get_or_panic(
                         raw_base_list,
                         first_index_val,
-                        "List index out of bounds in nested assignment",
+                        Some(indices[0].span()),
                         "nested_assign_list",
                     )?
                 }
@@ -4134,7 +4206,7 @@ impl<'a> CodeGenerator<'a> {
                     self.map_get_or_panic(
                         raw_base_map,
                         first_index_val,
-                        "Key not found in map during nested assignment",
+                        Some(indices[0].span()),
                         "nested_assign_map",
                     )?
                 }
@@ -4146,61 +4218,8 @@ impl<'a> CodeGenerator<'a> {
                 }
             };
 
-            // Check for null (out of bounds) - only for Lists
-            // Maps already handled the error case above
-            if matches!(base_type, crate::semantics::Type::List(_)) {
-                let intermediate_ptr = intermediate_val.into_pointer_value();
-                let is_null = self
-                    .builder
-                    .build_is_null(intermediate_ptr, "is_null")
-                    .map_err(|e| e.to_string())?;
-
-                let current_function = self
-                    .builder
-                    .get_insert_block()
-                    .expect("Builder should have an insertion block")
-                    .get_parent()
-                    .ok_or("No current function")?;
-
-                let error_bb = self
-                    .context
-                    .append_basic_block(current_function, "nested_index_error");
-                let continue_bb = self
-                    .context
-                    .append_basic_block(current_function, "nested_index_continue");
-
-                self.builder
-                    .build_conditional_branch(is_null, error_bb, continue_bb)
-                    .map_err(|e| e.to_string())?;
-
-                // Error block
-                self.builder.position_at_end(error_bb);
-                let error_msg = self
-                    .builder
-                    .build_global_string_ptr(
-                        "Index out of bounds in nested assignment",
-                        "nested_error_msg",
-                    )
-                    .map_err(|e| e.to_string())?;
-                let error_str = self
-                    .generate_runtime_call(
-                        "mux_new_string_from_cstr",
-                        &[error_msg.as_pointer_value().into()],
-                    )
-                    .expect("mux_new_string_from_cstr should always return a value");
-                self.generate_runtime_call("mux_print", &[error_str.into()]);
-                self.generate_runtime_call("mux_flush_stdout", &[]);
-                self.generate_runtime_call(
-                    "exit",
-                    &[self.context.i32_type().const_int(1, false).into()],
-                );
-                self.builder
-                    .build_unreachable()
-                    .map_err(|e| e.to_string())?;
-
-                // Continue block
-                self.builder.position_at_end(continue_bb);
-            }
+            // list_get_or_panic / map_get_or_panic already panicked on a
+            // missing element, so intermediate_val is guaranteed non-null.
 
             // Now we need to handle: intermediate_val[i2]...[iN] = value
             // But intermediate_val is a *mut Value, not an ExpressionNode
@@ -4330,7 +4349,7 @@ impl<'a> CodeGenerator<'a> {
                     self.list_get_or_panic(
                         raw_list,
                         first_index_val,
-                        "Index out of bounds in nested assignment",
+                        Some(indices[0].span()),
                         "apply_list",
                     )?
                 }
@@ -4353,7 +4372,7 @@ impl<'a> CodeGenerator<'a> {
                     self.map_get_or_panic(
                         raw_map,
                         first_index_val,
-                        "Key not found in map during nested assignment",
+                        Some(indices[0].span()),
                         "apply_map",
                     )?
                 }

--- a/mux-compiler/src/codegen/mod.rs
+++ b/mux-compiler/src/codegen/mod.rs
@@ -61,6 +61,7 @@ pub struct CodeGenerator<'a> {
     context_stack: Vec<GenericContext>,
     generated_methods: HashMap<String, bool>,
     rc_scope_stack: Vec<Vec<(String, PointerValue<'a>)>>,
+    source_name: String,
 }
 
 impl<'a> CodeGenerator<'a> {
@@ -400,7 +401,11 @@ impl<'a> CodeGenerator<'a> {
 
     // small helpers for runtime declarations were moved to runtime.rs
 
-    pub fn new(context: &'a Context, analyzer: &'a mut SemanticAnalyzer) -> Self {
+    pub fn new(
+        context: &'a Context,
+        analyzer: &'a mut SemanticAnalyzer,
+        source_name: &str,
+    ) -> Self {
         let module = context.create_module("mux_module");
         let runtime_signatures = context.create_module("mux_runtime_signatures");
         let builder = context.create_builder();
@@ -471,7 +476,14 @@ impl<'a> CodeGenerator<'a> {
             context_stack: Vec::new(),
             generated_methods: HashMap::new(),
             rc_scope_stack: Vec::new(),
+            source_name: source_name.to_string(),
         }
+    }
+
+    /// Render a `file:line:col` location for runtime panic messages, matching
+    /// the compiler diagnostic emitter's `--> file:line:col` locator.
+    fn panic_location(&self, span: &crate::lexer::Span) -> String {
+        format!("{}:{}:{}", self.source_name, span.row_start, span.col_start)
     }
 
     // Runtime declarations are implemented in the `runtime` submodule to keep

--- a/mux-compiler/src/codegen/operators.rs
+++ b/mux-compiler/src/codegen/operators.rs
@@ -8,7 +8,8 @@
 
 use inkwell::values::{BasicValueEnum, IntValue, PointerValue};
 
-use crate::ast::{BinaryOp, ExpressionKind, ExpressionNode, LiteralNode, PrimitiveType};
+use crate::ast::{BinaryOp, ExpressionKind, ExpressionNode, LiteralNode, PrimitiveType, Spanned};
+use crate::lexer::Span;
 use crate::semantics::Type;
 
 use super::CodeGenerator;
@@ -658,10 +659,12 @@ impl<'a> CodeGenerator<'a> {
         &mut self,
         left: BasicValueEnum<'a>,
         right: BasicValueEnum<'a>,
+        span: Option<&Span>,
     ) -> Result<BasicValueEnum<'a>, String> {
         if let (Ok(left_int), Ok(right_int)) =
             (self.get_raw_int_value(left), self.get_raw_int_value(right))
         {
+            self.emit_div_by_zero_check(right_int, span, "div")?;
             self.builder
                 .build_int_signed_div(left_int, right_int, "div")
                 .map_err(|e| e.to_string())
@@ -670,6 +673,7 @@ impl<'a> CodeGenerator<'a> {
             self.get_raw_float_value(left),
             self.get_raw_float_value(right),
         ) {
+            // Float division follows IEEE 754 semantics (inf/nan), no check.
             self.builder
                 .build_float_div(left_float, right_float, "fdiv")
                 .map_err(|e| e.to_string())
@@ -677,6 +681,54 @@ impl<'a> CodeGenerator<'a> {
         } else {
             Err("Unsupported div operands".to_string())
         }
+    }
+
+    /// Panic with "division by zero" if the integer divisor is zero.
+    /// Positions the builder at a new "continue" block for the division.
+    fn emit_div_by_zero_check(
+        &mut self,
+        divisor: IntValue<'a>,
+        span: Option<&Span>,
+        block_prefix: &str,
+    ) -> Result<(), String> {
+        let zero = divisor.get_type().const_zero();
+        let is_zero = self
+            .builder
+            .build_int_compare(
+                inkwell::IntPredicate::EQ,
+                divisor,
+                zero,
+                &format!("{}_is_zero", block_prefix),
+            )
+            .map_err(|e| e.to_string())?;
+
+        let current_function = self
+            .builder
+            .get_insert_block()
+            .expect("Builder should have an insertion block")
+            .get_parent()
+            .ok_or("No current function")?;
+
+        let error_bb = self
+            .context
+            .append_basic_block(current_function, &format!("{}_zero_error", block_prefix));
+        let continue_bb = self
+            .context
+            .append_basic_block(current_function, &format!("{}_zero_continue", block_prefix));
+
+        self.builder
+            .build_conditional_branch(is_zero, error_bb, continue_bb)
+            .map_err(|e| e.to_string())?;
+
+        self.builder.position_at_end(error_bb);
+        let loc = self.panic_location_arg(span, &format!("{}_zero_error", block_prefix))?;
+        self.generate_runtime_call("mux_panic_div_by_zero", &[loc.into()]);
+        self.builder
+            .build_unreachable()
+            .map_err(|e| e.to_string())?;
+
+        self.builder.position_at_end(continue_bb);
+        Ok(())
     }
 
     fn generate_exponent_op(
@@ -722,10 +774,12 @@ impl<'a> CodeGenerator<'a> {
         &mut self,
         left: BasicValueEnum<'a>,
         right: BasicValueEnum<'a>,
+        span: Option<&Span>,
     ) -> Result<BasicValueEnum<'a>, String> {
         if let (Ok(left_int), Ok(right_int)) =
             (self.get_raw_int_value(left), self.get_raw_int_value(right))
         {
+            self.emit_div_by_zero_check(right_int, span, "mod")?;
             self.builder
                 .build_int_signed_rem(left_int, right_int, "mod")
                 .map_err(|e| e.to_string())
@@ -989,7 +1043,7 @@ impl<'a> CodeGenerator<'a> {
             BinaryOp::Add => self.generate_add_op(left_expr, left, right),
             BinaryOp::Subtract => self.generate_subtract_op(left, right),
             BinaryOp::Multiply => self.generate_multiply_op(left, right),
-            BinaryOp::Divide => self.generate_divide_op(left, right),
+            BinaryOp::Divide => self.generate_divide_op(left, right, Some(right_expr.span())),
             BinaryOp::Exponent => self.generate_exponent_op(left, right),
             BinaryOp::Equal => self.generate_equal_op(left_expr, left, right),
             BinaryOp::Less => self.generate_numeric_compare(
@@ -1026,7 +1080,7 @@ impl<'a> CodeGenerator<'a> {
                 // and should not reach here
                 Err("Logical AND/OR should use short-circuit evaluation".to_string())
             }
-            BinaryOp::Modulo => self.generate_modulo_op(left, right),
+            BinaryOp::Modulo => self.generate_modulo_op(left, right, Some(right_expr.span())),
             BinaryOp::In => self.generate_in_op(left_expr, right_expr, left, right),
             _ => Err("Binary op not implemented".to_string()),
         }

--- a/mux-compiler/src/codegen/operators.rs
+++ b/mux-compiler/src/codegen/operators.rs
@@ -664,7 +664,7 @@ impl<'a> CodeGenerator<'a> {
         if let (Ok(left_int), Ok(right_int)) =
             (self.get_raw_int_value(left), self.get_raw_int_value(right))
         {
-            self.emit_div_by_zero_check(right_int, span, "div")?;
+            self.emit_div_by_zero_check(right_int, span, "div", "division by zero")?;
             self.builder
                 .build_int_signed_div(left_int, right_int, "div")
                 .map_err(|e| e.to_string())
@@ -683,13 +683,15 @@ impl<'a> CodeGenerator<'a> {
         }
     }
 
-    /// Panic with "division by zero" if the integer divisor is zero.
-    /// Positions the builder at a new "continue" block for the division.
+    /// Panic with `message` if the integer `divisor` is zero, so division and
+    /// modulo can report their own operation. Positions the builder at a new
+    /// "continue" block for the operation.
     fn emit_div_by_zero_check(
         &mut self,
         divisor: IntValue<'a>,
         span: Option<&Span>,
         block_prefix: &str,
+        message: &str,
     ) -> Result<(), String> {
         let zero = divisor.get_type().const_zero();
         let is_zero = self
@@ -721,8 +723,15 @@ impl<'a> CodeGenerator<'a> {
             .map_err(|e| e.to_string())?;
 
         self.builder.position_at_end(error_bb);
+        let msg = self
+            .builder
+            .build_global_string_ptr(message, &format!("{}_zero_msg", block_prefix))
+            .map_err(|e| e.to_string())?;
         let loc = self.panic_location_arg(span, &format!("{}_zero_error", block_prefix))?;
-        self.generate_runtime_call("mux_panic_div_by_zero", &[loc.into()]);
+        self.generate_runtime_call(
+            "mux_panic_cstr",
+            &[msg.as_pointer_value().into(), loc.into()],
+        );
         self.builder
             .build_unreachable()
             .map_err(|e| e.to_string())?;
@@ -779,7 +788,7 @@ impl<'a> CodeGenerator<'a> {
         if let (Ok(left_int), Ok(right_int)) =
             (self.get_raw_int_value(left), self.get_raw_int_value(right))
         {
-            self.emit_div_by_zero_check(right_int, span, "mod")?;
+            self.emit_div_by_zero_check(right_int, span, "mod", "modulo by zero")?;
             self.builder
                 .build_int_signed_rem(left_int, right_int, "mod")
                 .map_err(|e| e.to_string())

--- a/mux-compiler/src/codegen/runtime.rs
+++ b/mux-compiler/src/codegen/runtime.rs
@@ -130,11 +130,6 @@ impl<'a> CodeGenerator<'a> {
             None,
         );
         module.add_function(
-            "mux_panic",
-            void_type.fn_type(&[i8_ptr.into()], false),
-            None,
-        );
-        module.add_function(
             "mux_panic_cstr",
             void_type.fn_type(&[i8_ptr.into(), i8_ptr.into()], false),
             None,
@@ -147,11 +142,6 @@ impl<'a> CodeGenerator<'a> {
         module.add_function(
             "mux_panic_key_not_found",
             void_type.fn_type(&[i8_ptr.into(), i8_ptr.into()], false),
-            None,
-        );
-        module.add_function(
-            "mux_panic_div_by_zero",
-            void_type.fn_type(&[i8_ptr.into()], false),
             None,
         );
         module.add_function("malloc", i8_ptr.fn_type(&[i64_type.into()], false), None);

--- a/mux-compiler/src/codegen/runtime.rs
+++ b/mux-compiler/src/codegen/runtime.rs
@@ -129,6 +129,31 @@ impl<'a> CodeGenerator<'a> {
             void_type.fn_type(&[context.i32_type().into()], false),
             None,
         );
+        module.add_function(
+            "mux_panic",
+            void_type.fn_type(&[i8_ptr.into()], false),
+            None,
+        );
+        module.add_function(
+            "mux_panic_cstr",
+            void_type.fn_type(&[i8_ptr.into(), i8_ptr.into()], false),
+            None,
+        );
+        module.add_function(
+            "mux_panic_index_oob",
+            void_type.fn_type(&[i64_type.into(), i64_type.into(), i8_ptr.into()], false),
+            None,
+        );
+        module.add_function(
+            "mux_panic_key_not_found",
+            void_type.fn_type(&[i8_ptr.into(), i8_ptr.into()], false),
+            None,
+        );
+        module.add_function(
+            "mux_panic_div_by_zero",
+            void_type.fn_type(&[i8_ptr.into()], false),
+            None,
+        );
         module.add_function("malloc", i8_ptr.fn_type(&[i64_type.into()], false), None);
 
         let params = &[i8_ptr.into(), i8_ptr.into()];
@@ -1442,25 +1467,7 @@ impl<'a> CodeGenerator<'a> {
             .map_err(|e| e.to_string())?;
 
         self.builder.position_at_end(error_bb);
-        let error_msg = self
-            .builder
-            .build_global_string_ptr("Cannot copy object of this type", "copy_error_msg")
-            .map_err(|e| e.to_string())?;
-        let error_str = self
-            .generate_runtime_call(
-                "mux_new_string_from_cstr",
-                &[error_msg.as_pointer_value().into()],
-            )
-            .ok_or("mux_new_string_from_cstr should always return a value")?;
-        self.generate_runtime_call("mux_print", &[error_str.into()]);
-        self.generate_runtime_call("mux_flush_stdout", &[]);
-        self.generate_runtime_call(
-            "exit",
-            &[self.context.i32_type().const_int(1, false).into()],
-        );
-        self.builder
-            .build_unreachable()
-            .map_err(|e| e.to_string())?;
+        self.emit_runtime_fatal("cannot copy object of this type", None, "copy_error")?;
 
         self.builder.position_at_end(continue_bb);
         Ok(copied)

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -847,7 +847,11 @@ fn main() {
     let runtime_features = resolve_runtime_features(&analyzer.required_runtime_features());
 
     let context = inkwell::context::Context::create();
-    let mut codegen = codegen::CodeGenerator::new(&context, &mut analyzer);
+    let source_name = file_path
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| file_path.to_string_lossy().into_owned());
+    let mut codegen = codegen::CodeGenerator::new(&context, &mut analyzer, &source_name);
 
     let ir_file = format!(
         "{}.ll",

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_assert_failure.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_assert_failure.snap
@@ -2,5 +2,4 @@
 source: mux-compiler/tests/executable_integration.rs
 expression: normalized
 ---
-panic: key not found in map: key c
---> semantic_key_not_found.mux:3:12
+panic: assertion failed: expected 2, got 1

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_div_by_zero.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_div_by_zero.snap
@@ -2,5 +2,5 @@
 source: mux-compiler/tests/executable_integration.rs
 expression: normalized
 ---
-panic: key not found in map: key c
---> semantic_key_not_found.mux:3:12
+panic: division by zero
+--> runtime_div_by_zero.mux:5:20

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_list_index_oob.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_list_index_oob.snap
@@ -1,0 +1,6 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+panic: list index out of bounds: index 5, length 3
+--> runtime_list_index_oob.mux:5:14

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_map_key_not_found.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_map_key_not_found.snap
@@ -2,5 +2,5 @@
 source: mux-compiler/tests/executable_integration.rs
 expression: normalized
 ---
-panic: key not found in map: key c
---> semantic_key_not_found.mux:3:12
+panic: key not found in map: key bob
+--> runtime_map_key_not_found.mux:5:12

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_mod_by_zero.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_mod_by_zero.snap
@@ -2,5 +2,5 @@
 source: mux-compiler/tests/executable_integration.rs
 expression: normalized
 ---
-panic: key not found in map: key c
---> semantic_key_not_found.mux:3:12
+panic: division by zero
+--> runtime_mod_by_zero.mux:5:16

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_mod_by_zero.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_mod_by_zero.snap
@@ -2,5 +2,5 @@
 source: mux-compiler/tests/executable_integration.rs
 expression: normalized
 ---
-panic: division by zero
+panic: modulo by zero
 --> runtime_mod_by_zero.mux:5:16

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_index_out_of_bounds.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_index_out_of_bounds.snap
@@ -1,6 +1,6 @@
 ---
 source: mux-compiler/tests/executable_integration.rs
-expression: output_to_snapshot
+expression: normalized
 ---
-List index out of bounds
-Program exited with status: exit status: 1
+panic: list index out of bounds: index 10, length 3
+--> semantic_index_out_of_bounds.mux:3:14

--- a/test_scripts/error_cases/runtime_assert_failure.mux
+++ b/test_scripts/error_cases/runtime_assert_failure.mux
@@ -1,0 +1,5 @@
+// A failing assert routes through the unified runtime panic (exit code 1).
+
+import std.assert
+
+assert.assert_eq(1, 2)

--- a/test_scripts/error_cases/runtime_div_by_zero.mux
+++ b/test_scripts/error_cases/runtime_div_by_zero.mux
@@ -1,0 +1,5 @@
+// Integer division by zero panics with the unified runtime panic.
+
+int numerator = 10
+int denominator = 0
+print((numerator / denominator).to_string())

--- a/test_scripts/error_cases/runtime_list_index_oob.mux
+++ b/test_scripts/error_cases/runtime_list_index_oob.mux
@@ -1,0 +1,5 @@
+// Out-of-bounds list indexing panics with index and length details.
+
+auto values = [1, 2, 3]
+int position = 5
+print(values[position].to_string())

--- a/test_scripts/error_cases/runtime_map_key_not_found.mux
+++ b/test_scripts/error_cases/runtime_map_key_not_found.mux
@@ -1,0 +1,5 @@
+// Missing map key panics with the offending key.
+
+map<string, int> ages = {"alice": 30}
+string missing = "bob"
+print(ages[missing].to_string())

--- a/test_scripts/error_cases/runtime_mod_by_zero.mux
+++ b/test_scripts/error_cases/runtime_mod_by_zero.mux
@@ -1,0 +1,5 @@
+// Integer modulo by zero panics with the unified runtime panic.
+
+int value = 10
+int divisor = 0
+print((value % divisor).to_string())


### PR DESCRIPTION
## Summary

Unifies every runtime failure path onto a single panic primitive and gives them
a consistent, source-located format. Closes #225.

Before this, Mux had three inconsistent runtime-failure paths:
- container errors (index/key) → message to **stdout**, exit 1
- `std.assert` → **stderr**, `abort()` (SIGABRT / exit 134)
- integer division by zero → **unguarded** (raw SIGFPE)

## What changed

- Route `emit_runtime_fatal` through the runtime's `mux_panic_cstr` (stderr +
  exit 1) instead of `mux_print` (stdout) + `exit(1)`.
- List index out-of-bounds now reports the index and length; map key-not-found
  reports the key; both carry a `file:line:col` source location.
- Integer `/` and `%` emit a zero-check that panics with `division by zero`;
  float division keeps IEEE (inf/NaN) semantics.
- Panic output matches the compiler's diagnostic style — `panic: <message>` +
  `--> file:line:col`, with dynamic detail folded into the message. No source
  snippet is baked in, so there is **no binary-size cost**.
- New `error_cases/runtime_{div_by_zero,mod_by_zero,list_index_oob,
  map_key_not_found,assert_failure}.mux` scripts; `.gitignore` fixed so
  `error_cases/*.mux` can be committed.

## Format

```
panic: division by zero
--> math.mux:4:16

panic: list index out of bounds: index 5, length 3
--> main.mux:9:14

panic: key not found in map: key bob
--> lookup.mux:12:12

panic: assertion failed: expected 2, got 1
```

## Behavior change

Runtime failures now uniformly go to **stderr** and exit **1** (asserts were
134). Executable-integration snapshots updated accordingly.

## Sequencing

Depends on the runtime PR: CI builds the runtime from `main` source, so the
runtime change must land first for the `mux_panic_*` symbols to link here.

## Testing

`cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt` clean;
error cases verified end-to-end (exact stderr + exit codes); happy paths
unaffected.