### PR TITLE
feat: reject provable runtime panics at compile time

### DIFF
--- a/docs/error-corpus/semantic.json
+++ b/docs/error-corpus/semantic.json
@@ -88,5 +88,93 @@
     "relevant_docs": [
       "/docs/language-guide/functions/"
     ]
+  },
+  {
+    "id": "semantic_where_always_false",
+    "source": "func f(int a) where { 1 > 2 } returns int { return a }",
+    "error": "where predicate is always false",
+    "help": "This predicate can never hold, so every check of it would panic. Fix the condition or remove it.",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/functions/"]
+  },
+  {
+    "id": "semantic_div_by_zero_literal",
+    "source": "print((10 / 0).to_string())",
+    "error": "division by zero",
+    "help": "The divisor is always zero, so this operation would panic on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/types/"]
+  },
+  {
+    "id": "semantic_mod_by_zero_literal",
+    "source": "print((10 % 0).to_string())",
+    "error": "modulo by zero",
+    "help": "The divisor is always zero, so this operation would panic on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/types/"]
+  },
+  {
+    "id": "semantic_where_call_violation",
+    "source": "func divide(float a, float b) where { b != 0.0 } returns float { return a / b }\nprint(divide(10.0, 0.0).to_string())",
+    "error": "arguments to 'divide' violate its where constraint",
+    "help": "The where predicate at 1:39 is always false for these argument values, so this call would panic on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/functions/"]
+  },
+  {
+    "id": "semantic_where_enum_violation",
+    "source": "enum Status { Unknown, Code(int value) where { value >= 100, value <= 599 } }\nauto bad = Status.Code(9999)",
+    "error": "arguments to 'Status.Code' violate its where constraint",
+    "help": "The where predicate at 1:48 is always false for these argument values, so this call would panic on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/enums/"]
+  },
+  {
+    "id": "semantic_where_inherited_violation",
+    "source": "interface Divider { func div(int n) where { n != 0 } returns int }\nclass Calc is Divider { int total\n    func div(int amount) returns int { return 100 / amount } }\nauto c = Calc.new()\nprint(c.div(0).to_string())",
+    "error": "arguments to 'Calc.div' violate its where constraint",
+    "help": "The where predicate at 1:45 is always false for these argument values, so this call would panic on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/classes/"]
+  },
+  {
+    "id": "semantic_where_assign_violation",
+    "source": "class Port { int number = 80 where { number > 0, number < 65535 } }\nauto p = Port.new()\np.number = 70000",
+    "error": "assignment violates where constraint of 'Port.number'",
+    "help": "The where predicate at 1:38 is always false for this value, so this assignment would panic on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/classes/"]
+  },
+  {
+    "id": "semantic_where_default_violation",
+    "source": "class Account { int balance where { balance >= 100 } }\nauto a = Account.new()",
+    "error": "field defaults violate this where constraint at construction",
+    "help": "Invariants are checked when .new() runs, after field defaults are applied, so every construction would panic. Give the constrained fields defaults that satisfy this predicate.",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/classes/"]
+  },
+  {
+    "id": "semantic_list_index_negative",
+    "source": "auto nums = [1, 2, 3]\nprint(nums[-1].to_string())",
+    "error": "list index out of bounds: index -1",
+    "help": "List indices start at 0; a negative index panics on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/collections/"]
+  },
+  {
+    "id": "semantic_list_index_oob",
+    "source": "print([1, 2, 3][5].to_string())",
+    "error": "list index out of bounds: index 5, length 3",
+    "help": "The index is always outside this list, so the access would panic on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/collections/"]
+  },
+  {
+    "id": "semantic_map_key_not_found",
+    "source": "print({\"a\": 1, \"b\": 2}[\"c\"].to_string())",
+    "error": "key not found in map: key c",
+    "help": "The key is never present in this map literal, so the lookup would panic on every execution",
+    "category": "semantic",
+    "relevant_docs": ["/docs/language-guide/collections/"]
   }
 ]

--- a/mux-compiler/src/codegen/where_clause.rs
+++ b/mux-compiler/src/codegen/where_clause.rs
@@ -11,6 +11,7 @@ use inkwell::values::PointerValue;
 
 use crate::ast::{ExpressionNode, FunctionNode};
 use crate::semantics::Type;
+use crate::semantics::const_fold::{self, ConstValue};
 
 use super::CodeGenerator;
 
@@ -23,6 +24,12 @@ impl<'a> CodeGenerator<'a> {
         block_prefix: &str,
     ) -> Result<(), String> {
         for (i, predicate) in predicates.iter().enumerate() {
+            // A predicate that folds to true from literals alone can never
+            // fail; skip the branch. The folder never short-circuits, so no
+            // runtime evaluation is dropped.
+            if const_fold::fold(predicate) == Some(ConstValue::Bool(true)) {
+                continue;
+            }
             let value = self.generate_expression(predicate)?;
             let cond = self.get_raw_bool_value(value)?;
 

--- a/mux-compiler/src/semantics/const_checks.rs
+++ b/mux-compiler/src/semantics/const_checks.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 
 use super::const_fold::{self, ConstValue};
 use super::{SemanticAnalyzer, SemanticError, SymbolKind, Type};
-use crate::ast::{AstNode, BinaryOp, ExpressionKind, ExpressionNode};
+use crate::ast::{AstNode, BinaryOp, EnumVariant, ExpressionKind, ExpressionNode, FunctionNode};
 use crate::lexer::Span;
 
 /// A function's or method's `where` predicates with what a call site needs to
@@ -58,57 +58,70 @@ impl SemanticAnalyzer {
         variants: &mut HashMap<(String, String), EnumVariantPreconditions>,
         poisoned: &mut Vec<(String, String)>,
     ) {
-        let mut record = |key: (String, String), value: WherePreconditions| {
-            if let Some(previous) = functions.insert(key.clone(), value.clone())
-                && previous != value
-            {
-                poisoned.push(key);
-            }
-        };
         for node in nodes {
             match node {
                 AstNode::Function(func) => {
-                    if let Some(clause) = &func.where_clause {
-                        record(
-                            (String::new(), func.name.clone()),
-                            Self::make_preconditions(&func.params, &clause.predicates),
-                        );
-                    }
+                    Self::record_function_preconditions(String::new(), func, functions, poisoned);
                 }
                 AstNode::Class { name, methods, .. } => {
                     for method in methods {
-                        if let Some(clause) = &method.where_clause {
-                            record(
-                                (name.clone(), method.name.clone()),
-                                Self::make_preconditions(&method.params, &clause.predicates),
-                            );
-                        }
+                        Self::record_function_preconditions(
+                            name.clone(),
+                            method,
+                            functions,
+                            poisoned,
+                        );
                     }
                 }
                 AstNode::Enum {
                     name,
                     variants: enum_variants,
                     ..
-                } => {
-                    for variant in enum_variants {
-                        if let Some(clause) = &variant.where_clause {
-                            variants.insert(
-                                (name.clone(), variant.name.clone()),
-                                EnumVariantPreconditions {
-                                    field_names: variant
-                                        .data
-                                        .iter()
-                                        .flatten()
-                                        .map(|(field_name, _)| field_name.clone())
-                                        .collect(),
-                                    predicates: clause.predicates.clone(),
-                                },
-                            );
-                        }
-                    }
-                }
+                } => Self::record_enum_preconditions(name, enum_variants, variants),
                 _ => {}
             }
+        }
+    }
+
+    fn record_function_preconditions(
+        owner: String,
+        func: &FunctionNode,
+        functions: &mut HashMap<(String, String), WherePreconditions>,
+        poisoned: &mut Vec<(String, String)>,
+    ) {
+        let Some(clause) = &func.where_clause else {
+            return;
+        };
+        let key = (owner, func.name.clone());
+        let value = Self::make_preconditions(&func.params, &clause.predicates);
+        if let Some(previous) = functions.insert(key.clone(), value.clone())
+            && previous != value
+        {
+            poisoned.push(key);
+        }
+    }
+
+    fn record_enum_preconditions(
+        enum_name: &str,
+        enum_variants: &[EnumVariant],
+        variants: &mut HashMap<(String, String), EnumVariantPreconditions>,
+    ) {
+        for variant in enum_variants {
+            let Some(clause) = &variant.where_clause else {
+                continue;
+            };
+            variants.insert(
+                (enum_name.to_string(), variant.name.clone()),
+                EnumVariantPreconditions {
+                    field_names: variant
+                        .data
+                        .iter()
+                        .flatten()
+                        .map(|(field_name, _)| field_name.clone())
+                        .collect(),
+                    predicates: clause.predicates.clone(),
+                },
+            );
         }
     }
 

--- a/mux-compiler/src/semantics/const_checks.rs
+++ b/mux-compiler/src/semantics/const_checks.rs
@@ -1,0 +1,479 @@
+//! Compile-time detection of guaranteed runtime panics.
+//!
+//! Every check here fires only when the panic is provable from literals via
+//! `const_fold`; anything unknown keeps the runtime check as the fallback.
+//! Covered: `where` violations at call sites (functions, methods, enum
+//! variants, interface preconditions), literal integer division/modulo by
+//! zero, provably out-of-bounds list indices, and missing keys in map
+//! literals. Always-false predicates and field defaults that violate class
+//! invariants are reported from `where_clause.rs` with the same folder.
+
+use std::collections::HashMap;
+
+use super::const_fold::{self, ConstValue};
+use super::{SemanticAnalyzer, SemanticError, SymbolKind, Type};
+use crate::ast::{AstNode, BinaryOp, ExpressionKind, ExpressionNode};
+use crate::lexer::Span;
+
+/// A function's or method's `where` predicates with what a call site needs to
+/// evaluate them: parameter names and any default argument expressions.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WherePreconditions {
+    pub param_names: Vec<String>,
+    pub param_defaults: Vec<Option<ExpressionNode>>,
+    pub predicates: Vec<ExpressionNode>,
+}
+
+/// An enum variant's `where` predicates keyed to its named payload fields.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EnumVariantPreconditions {
+    pub field_names: Vec<Option<String>>,
+    pub predicates: Vec<ExpressionNode>,
+}
+
+impl SemanticAnalyzer {
+    /// Collect the `where` preconditions of every function, method, and enum
+    /// variant across all modules, before the analysis pass, so call sites
+    /// can check them regardless of declaration order. A name that maps to
+    /// two different declarations across modules is dropped entirely: a
+    /// wrong-callee check would be a false positive.
+    pub(super) fn collect_where_preconditions(&mut self, ast: &[AstNode]) {
+        let mut functions = HashMap::new();
+        let mut variants = HashMap::new();
+        let mut poisoned = Vec::new();
+        for nodes in self.all_module_asts.values() {
+            Self::extract_where_preconditions(nodes, &mut functions, &mut variants, &mut poisoned);
+        }
+        Self::extract_where_preconditions(ast, &mut functions, &mut variants, &mut poisoned);
+        for key in poisoned {
+            functions.remove(&key);
+        }
+        self.function_preconditions = functions;
+        self.enum_variant_preconditions = variants;
+    }
+
+    fn extract_where_preconditions(
+        nodes: &[AstNode],
+        functions: &mut HashMap<(String, String), WherePreconditions>,
+        variants: &mut HashMap<(String, String), EnumVariantPreconditions>,
+        poisoned: &mut Vec<(String, String)>,
+    ) {
+        let mut record = |key: (String, String), value: WherePreconditions| {
+            if let Some(previous) = functions.insert(key.clone(), value.clone())
+                && previous != value
+            {
+                poisoned.push(key);
+            }
+        };
+        for node in nodes {
+            match node {
+                AstNode::Function(func) => {
+                    if let Some(clause) = &func.where_clause {
+                        record(
+                            (String::new(), func.name.clone()),
+                            Self::make_preconditions(&func.params, &clause.predicates),
+                        );
+                    }
+                }
+                AstNode::Class { name, methods, .. } => {
+                    for method in methods {
+                        if let Some(clause) = &method.where_clause {
+                            record(
+                                (name.clone(), method.name.clone()),
+                                Self::make_preconditions(&method.params, &clause.predicates),
+                            );
+                        }
+                    }
+                }
+                AstNode::Enum {
+                    name,
+                    variants: enum_variants,
+                    ..
+                } => {
+                    for variant in enum_variants {
+                        if let Some(clause) = &variant.where_clause {
+                            variants.insert(
+                                (name.clone(), variant.name.clone()),
+                                EnumVariantPreconditions {
+                                    field_names: variant
+                                        .data
+                                        .iter()
+                                        .flatten()
+                                        .map(|(field_name, _)| field_name.clone())
+                                        .collect(),
+                                    predicates: clause.predicates.clone(),
+                                },
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn make_preconditions(
+        params: &[crate::ast::Param],
+        predicates: &[ExpressionNode],
+    ) -> WherePreconditions {
+        WherePreconditions {
+            param_names: params.iter().map(|p| p.name.clone()).collect(),
+            param_defaults: params.iter().map(|p| p.default_value.clone()).collect(),
+            predicates: predicates.to_vec(),
+        }
+    }
+
+    /// At a call site, if the callee has `where` preconditions and every value
+    /// a predicate needs folds to a constant, report a predicate that folds to
+    /// false: the call would panic on every execution.
+    pub(super) fn check_call_preconditions(
+        &mut self,
+        expr: &ExpressionNode,
+        func: &ExpressionNode,
+        args: &[ExpressionNode],
+    ) -> Result<(), SemanticError> {
+        match &func.kind {
+            ExpressionKind::Identifier(name) => {
+                if self
+                    .symbol_table
+                    .lookup(name)
+                    .is_some_and(|s| s.kind == SymbolKind::Function)
+                    && let Some(pre) = self
+                        .function_preconditions
+                        .get(&(String::new(), name.clone()))
+                {
+                    let pre = pre.clone();
+                    return self.check_preconditions_against_args(expr, name, &pre, args);
+                }
+                Ok(())
+            }
+            ExpressionKind::FieldAccess { expr: inner, field } => {
+                self.check_qualified_call_preconditions(expr, inner, field, args)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn check_qualified_call_preconditions(
+        &mut self,
+        expr: &ExpressionNode,
+        inner: &ExpressionNode,
+        field: &str,
+        args: &[ExpressionNode],
+    ) -> Result<(), SemanticError> {
+        // Type-qualified call: enum variant constructor or common method.
+        if let ExpressionKind::Identifier(type_name) = &inner.kind {
+            match self.symbol_table.lookup(type_name).map(|s| s.kind.clone()) {
+                Some(SymbolKind::Enum) => {
+                    let key = (type_name.clone(), field.to_string());
+                    if let Some(pre) = self.enum_variant_preconditions.get(&key) {
+                        let pre = pre.clone();
+                        let display = format!("{}.{}", type_name, field);
+                        return self.check_variant_preconditions(expr, &display, &pre, args);
+                    }
+                    return Ok(());
+                }
+                Some(SymbolKind::Class) => {
+                    return self.check_method_preconditions(expr, type_name, field, args);
+                }
+                _ => {}
+            }
+        }
+        // Instance method call: resolve the receiver's class or interface.
+        match self.get_expression_type(inner) {
+            Ok(Type::Named(type_name, _)) => {
+                match self.symbol_table.lookup(&type_name).map(|s| s.kind.clone()) {
+                    Some(SymbolKind::Class) => {
+                        self.check_method_preconditions(expr, &type_name, field, args)
+                    }
+                    Some(SymbolKind::Interface) => {
+                        let inherited = self
+                            .interface_preconditions
+                            .get(&type_name)
+                            .and_then(|methods| methods.get(field))
+                            .cloned();
+                        if let Some(pre) = inherited {
+                            let display = format!("{}.{}", type_name, field);
+                            let pre = WherePreconditions {
+                                param_defaults: vec![None; pre.interface_param_names.len()],
+                                param_names: pre.interface_param_names,
+                                predicates: pre.predicates,
+                            };
+                            return self
+                                .check_preconditions_against_args(expr, &display, &pre, args);
+                        }
+                        Ok(())
+                    }
+                    _ => Ok(()),
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Check a class method's own preconditions plus the interface
+    /// preconditions it inherits, exactly the set codegen enforces at entry.
+    fn check_method_preconditions(
+        &mut self,
+        expr: &ExpressionNode,
+        class_name: &str,
+        method_name: &str,
+        args: &[ExpressionNode],
+    ) -> Result<(), SemanticError> {
+        let display = format!("{}.{}", class_name, method_name);
+        let key = (class_name.to_string(), method_name.to_string());
+        if let Some(pre) = self.function_preconditions.get(&key) {
+            let pre = pre.clone();
+            self.check_preconditions_against_args(expr, &display, &pre, args)?;
+        }
+        for inherited in self
+            .inherited_preconditions(class_name, method_name)
+            .to_vec()
+        {
+            let pre = WherePreconditions {
+                param_defaults: vec![None; inherited.interface_param_names.len()],
+                param_names: inherited.interface_param_names,
+                predicates: inherited.predicates,
+            };
+            self.check_preconditions_against_args(expr, &display, &pre, args)?;
+        }
+        Ok(())
+    }
+
+    fn check_preconditions_against_args(
+        &self,
+        expr: &ExpressionNode,
+        display_name: &str,
+        pre: &WherePreconditions,
+        args: &[ExpressionNode],
+    ) -> Result<(), SemanticError> {
+        if args.len() > pre.param_names.len() {
+            return Ok(());
+        }
+        let mut env = HashMap::new();
+        for (i, name) in pre.param_names.iter().enumerate() {
+            let value = if i < args.len() {
+                const_fold::fold(&args[i])
+            } else {
+                pre.param_defaults[i].as_ref().and_then(const_fold::fold)
+            };
+            if let Some(value) = value {
+                env.insert(name.clone(), value);
+            }
+        }
+        Self::report_false_predicate(&pre.predicates, &env, expr.span, || {
+            format!(
+                "arguments to '{}' violate its where constraint",
+                display_name
+            )
+        })
+    }
+
+    fn check_variant_preconditions(
+        &self,
+        expr: &ExpressionNode,
+        display_name: &str,
+        pre: &EnumVariantPreconditions,
+        args: &[ExpressionNode],
+    ) -> Result<(), SemanticError> {
+        if args.len() != pre.field_names.len() {
+            return Ok(());
+        }
+        let mut env = HashMap::new();
+        for (field_name, arg) in pre.field_names.iter().zip(args) {
+            if let Some(name) = field_name
+                && let Some(value) = const_fold::fold(arg)
+            {
+                env.insert(name.clone(), value);
+            }
+        }
+        Self::report_false_predicate(&pre.predicates, &env, expr.span, || {
+            format!(
+                "arguments to '{}' violate its where constraint",
+                display_name
+            )
+        })
+    }
+
+    fn report_false_predicate(
+        predicates: &[ExpressionNode],
+        env: &HashMap<String, ConstValue>,
+        span: Span,
+        message: impl Fn() -> String,
+    ) -> Result<(), SemanticError> {
+        for predicate in predicates {
+            // A predicate that is false with no bindings at all is already
+            // reported at its declaration ("where predicate is always
+            // false"); repeating it per call site would be noise.
+            if const_fold::fold(predicate) != Some(ConstValue::Bool(false))
+                && const_fold::fold_with_env(predicate, env) == Some(ConstValue::Bool(false))
+            {
+                return Err(SemanticError::with_help(
+                    message(),
+                    span,
+                    format!(
+                        "The where predicate at {}:{} is always false for these argument values, so this call would panic on every execution",
+                        predicate.span.row_start, predicate.span.col_start
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Report integer division/modulo whose divisor folds to zero, and field
+    /// assignments whose folded value violates a class invariant. Called from
+    /// the Binary analysis path after operand types have been validated.
+    pub(super) fn check_const_binary(
+        &mut self,
+        left: &ExpressionNode,
+        op: &BinaryOp,
+        op_span: &Span,
+        right: &ExpressionNode,
+    ) -> Result<(), SemanticError> {
+        match op {
+            BinaryOp::Divide
+            | BinaryOp::DivideAssign
+            | BinaryOp::Modulo
+            | BinaryOp::ModuloAssign => {
+                if const_fold::fold(right) == Some(ConstValue::Int(0)) {
+                    let operation = if matches!(op, BinaryOp::Divide | BinaryOp::DivideAssign) {
+                        "division"
+                    } else {
+                        "modulo"
+                    };
+                    return Err(SemanticError::with_help(
+                        format!("{} by zero", operation),
+                        *op_span,
+                        "The divisor is always zero, so this operation would panic on every execution",
+                    ));
+                }
+                Ok(())
+            }
+            BinaryOp::Assign => self.check_field_assignment_invariants(left, right),
+            _ => Ok(()),
+        }
+    }
+
+    /// A literal assigned to a constrained field is checked against every
+    /// invariant that references exactly that field; invariants involving
+    /// other fields depend on unknown state and stay runtime checks.
+    fn check_field_assignment_invariants(
+        &mut self,
+        left: &ExpressionNode,
+        right: &ExpressionNode,
+    ) -> Result<(), SemanticError> {
+        let ExpressionKind::FieldAccess { expr: obj, field } = &left.kind else {
+            return Ok(());
+        };
+        let Some(value) = const_fold::fold(right) else {
+            return Ok(());
+        };
+        let Ok(Type::Named(class_name, _)) = self.get_expression_type(obj) else {
+            return Ok(());
+        };
+        let invariants: Vec<ExpressionNode> = self
+            .class_invariants
+            .get(&class_name)
+            .map(|invariants| {
+                invariants
+                    .iter()
+                    .filter(|inv| inv.referenced_fields == [field.clone()])
+                    .map(|inv| inv.predicate.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut env = HashMap::new();
+        env.insert(field.clone(), value);
+        for predicate in &invariants {
+            if const_fold::fold_with_env(predicate, &env) == Some(ConstValue::Bool(false)) {
+                return Err(SemanticError::with_help(
+                    format!(
+                        "assignment violates where constraint of '{}.{}'",
+                        class_name, field
+                    ),
+                    right.span,
+                    format!(
+                        "The where predicate at {}:{} is always false for this value, so this assignment would panic on every execution",
+                        predicate.span.row_start, predicate.span.col_start
+                    ),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Report list indices that are provably out of bounds (negative, or past
+    /// the end of a list literal) and lookups of keys provably absent from a
+    /// map literal. Called after the index expression has been typechecked.
+    pub(super) fn check_const_index(
+        &self,
+        target: &ExpressionNode,
+        target_type: &Type,
+        index: &ExpressionNode,
+    ) -> Result<(), SemanticError> {
+        match target_type {
+            Type::List(_) => {
+                let Some(ConstValue::Int(value)) = const_fold::fold(index) else {
+                    return Ok(());
+                };
+                if value < 0 {
+                    return Err(SemanticError::with_help(
+                        format!("list index out of bounds: index {}", value),
+                        index.span,
+                        "List indices start at 0; a negative index panics on every execution",
+                    ));
+                }
+                if let ExpressionKind::ListLiteral(elements) = &target.kind
+                    && value >= elements.len() as i64
+                {
+                    return Err(SemanticError::with_help(
+                        format!(
+                            "list index out of bounds: index {}, length {}",
+                            value,
+                            elements.len()
+                        ),
+                        index.span,
+                        "The index is always outside this list, so the access would panic on every execution",
+                    ));
+                }
+                Ok(())
+            }
+            Type::Map(_, _) => self.check_map_literal_key(target, index),
+            _ => Ok(()),
+        }
+    }
+
+    fn check_map_literal_key(
+        &self,
+        target: &ExpressionNode,
+        index: &ExpressionNode,
+    ) -> Result<(), SemanticError> {
+        let ExpressionKind::MapLiteral { entries, .. } = &target.kind else {
+            return Ok(());
+        };
+        // Float keys are skipped: their equality is not worth mirroring.
+        let foldable_key = |expr: &ExpressionNode| match const_fold::fold(expr) {
+            Some(ConstValue::Float(_)) | None => None,
+            Some(value) => Some(value),
+        };
+        let Some(lookup) = foldable_key(index) else {
+            return Ok(());
+        };
+        let mut keys = Vec::with_capacity(entries.len());
+        for (key, _) in entries {
+            let Some(key) = foldable_key(key) else {
+                return Ok(());
+            };
+            keys.push(key);
+        }
+        if keys.contains(&lookup) {
+            return Ok(());
+        }
+        Err(SemanticError::with_help(
+            format!("key not found in map: key {}", lookup),
+            index.span,
+            "The key is never present in this map literal, so the lookup would panic on every execution",
+        ))
+    }
+}

--- a/mux-compiler/src/semantics/const_fold.rs
+++ b/mux-compiler/src/semantics/const_fold.rs
@@ -1,0 +1,265 @@
+//! Constant folding for compile-time panic detection.
+//!
+//! Evaluates an expression to a constant when every input is known, mirroring
+//! runtime semantics exactly. Whenever the result could differ from what the
+//! compiled program computes (integer overflow, NaN, unsupported operators,
+//! unknown identifiers), folding returns `None` and the caller stays silent:
+//! Mux has no warning level, so a check built on the folder must only fire
+//! when the panic is provable.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use crate::ast::{BinaryOp, ExpressionKind, ExpressionNode, LiteralNode, UnaryOp};
+
+/// A compile-time constant value with the same semantics as its runtime type.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConstValue {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Str(String),
+    Char(char),
+}
+
+impl fmt::Display for ConstValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConstValue::Int(v) => write!(f, "{}", v),
+            ConstValue::Float(v) => write!(f, "{}", v),
+            ConstValue::Bool(v) => write!(f, "{}", v),
+            ConstValue::Str(v) => write!(f, "{}", v),
+            ConstValue::Char(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+/// Fold an expression with no bindings: only literal-derived values succeed.
+pub fn fold(expr: &ExpressionNode) -> Option<ConstValue> {
+    fold_with_env(expr, &HashMap::new())
+}
+
+/// Fold an expression, resolving bare identifiers through `env`. Identifiers
+/// absent from `env` make the whole fold return `None`.
+pub fn fold_with_env(
+    expr: &ExpressionNode,
+    env: &HashMap<String, ConstValue>,
+) -> Option<ConstValue> {
+    match &expr.kind {
+        ExpressionKind::Literal(lit) => Some(match lit {
+            LiteralNode::Integer(v) => ConstValue::Int(*v),
+            LiteralNode::Float(v) => ConstValue::Float(v.into_inner()),
+            LiteralNode::Boolean(v) => ConstValue::Bool(*v),
+            LiteralNode::String(v) => ConstValue::Str(v.clone()),
+            LiteralNode::Char(v) => ConstValue::Char(*v),
+        }),
+        ExpressionKind::Identifier(name) => env.get(name).cloned(),
+        ExpressionKind::Unary { op, expr, .. } => {
+            let value = fold_with_env(expr, env)?;
+            fold_unary(op, value)
+        }
+        ExpressionKind::Binary {
+            left, op, right, ..
+        } => {
+            // No short-circuit folding: both sides must be known, so skipping
+            // a fold-true predicate in codegen can never drop an evaluation
+            // the runtime would have performed.
+            let l = fold_with_env(left, env)?;
+            let r = fold_with_env(right, env)?;
+            fold_binary(l, op, r)
+        }
+        _ => None,
+    }
+}
+
+fn fold_unary(op: &UnaryOp, value: ConstValue) -> Option<ConstValue> {
+    match (op, value) {
+        (UnaryOp::Neg, ConstValue::Int(v)) => v.checked_neg().map(ConstValue::Int),
+        (UnaryOp::Neg, ConstValue::Float(v)) => Some(ConstValue::Float(-v)),
+        (UnaryOp::Not, ConstValue::Bool(v)) => Some(ConstValue::Bool(!v)),
+        _ => None,
+    }
+}
+
+fn fold_binary(left: ConstValue, op: &BinaryOp, right: ConstValue) -> Option<ConstValue> {
+    use ConstValue::*;
+    match (left, right) {
+        (Int(l), Int(r)) => fold_int_op(l, op, r),
+        (Float(l), Float(r)) => fold_float_op(l, op, r),
+        (Bool(l), Bool(r)) => match op {
+            BinaryOp::Equal => Some(Bool(l == r)),
+            BinaryOp::NotEqual => Some(Bool(l != r)),
+            BinaryOp::LogicalAnd => Some(Bool(l && r)),
+            BinaryOp::LogicalOr => Some(Bool(l || r)),
+            _ => None,
+        },
+        (Str(l), Str(r)) => match op {
+            BinaryOp::Add => Some(Str(l + &r)),
+            BinaryOp::Equal => Some(Bool(l == r)),
+            BinaryOp::NotEqual => Some(Bool(l != r)),
+            _ => None,
+        },
+        (Char(l), Char(r)) => match op {
+            BinaryOp::Equal => Some(Bool(l == r)),
+            BinaryOp::NotEqual => Some(Bool(l != r)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn fold_int_op(l: i64, op: &BinaryOp, r: i64) -> Option<ConstValue> {
+    use ConstValue::{Bool, Int};
+    match op {
+        // checked_* bails on overflow (and on division by zero / MIN / -1),
+        // so the folder never has to guess wrap behavior. Division by zero is
+        // reported by its dedicated check, not through the folder.
+        BinaryOp::Add => l.checked_add(r).map(Int),
+        BinaryOp::Subtract => l.checked_sub(r).map(Int),
+        BinaryOp::Multiply => l.checked_mul(r).map(Int),
+        BinaryOp::Divide => l.checked_div(r).map(Int),
+        BinaryOp::Modulo => l.checked_rem(r).map(Int),
+        BinaryOp::Equal => Some(Bool(l == r)),
+        BinaryOp::NotEqual => Some(Bool(l != r)),
+        BinaryOp::Less => Some(Bool(l < r)),
+        BinaryOp::LessEqual => Some(Bool(l <= r)),
+        BinaryOp::Greater => Some(Bool(l > r)),
+        BinaryOp::GreaterEqual => Some(Bool(l >= r)),
+        // Exponent lowers through a runtime routine; not mirrored here.
+        _ => None,
+    }
+}
+
+fn fold_float_op(l: f64, op: &BinaryOp, r: f64) -> Option<ConstValue> {
+    use ConstValue::{Bool, Float};
+    let arith = |v: f64| {
+        // NaN comparison semantics are not worth mirroring; bail instead.
+        if v.is_nan() { None } else { Some(Float(v)) }
+    };
+    match op {
+        BinaryOp::Add => arith(l + r),
+        BinaryOp::Subtract => arith(l - r),
+        BinaryOp::Multiply => arith(l * r),
+        BinaryOp::Divide => arith(l / r),
+        BinaryOp::Modulo => arith(l % r),
+        // Literals are never NaN and arithmetic bails on NaN, so these
+        // ordered comparisons match LLVM's ordered fcmp on every input
+        // that can reach them.
+        BinaryOp::Equal => Some(Bool(l == r)),
+        BinaryOp::NotEqual => Some(Bool(l != r)),
+        BinaryOp::Less => Some(Bool(l < r)),
+        BinaryOp::LessEqual => Some(Bool(l <= r)),
+        BinaryOp::Greater => Some(Bool(l > r)),
+        BinaryOp::GreaterEqual => Some(Bool(l >= r)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{BinaryOp, ExpressionKind, ExpressionNode, LiteralNode, UnaryOp};
+    use crate::lexer::Span;
+
+    fn lit(l: LiteralNode) -> ExpressionNode {
+        l.into()
+    }
+
+    fn int(v: i64) -> ExpressionNode {
+        lit(LiteralNode::Integer(v))
+    }
+
+    fn ident(name: &str) -> ExpressionNode {
+        name.into()
+    }
+
+    fn binary(left: ExpressionNode, op: BinaryOp, right: ExpressionNode) -> ExpressionNode {
+        ExpressionNode {
+            kind: ExpressionKind::Binary {
+                left: Box::new(left),
+                op,
+                op_span: Span::new(0, 0),
+                right: Box::new(right),
+            },
+            span: Span::new(0, 0),
+        }
+    }
+
+    fn unary(op: UnaryOp, expr: ExpressionNode) -> ExpressionNode {
+        ExpressionNode {
+            kind: ExpressionKind::Unary {
+                op,
+                op_span: Span::new(0, 0),
+                expr: Box::new(expr),
+                postfix: false,
+            },
+            span: Span::new(0, 0),
+        }
+    }
+
+    #[test]
+    fn folds_int_arithmetic_and_comparisons() {
+        let e = binary(int(2), BinaryOp::Add, int(3));
+        assert_eq!(fold(&e), Some(ConstValue::Int(5)));
+        let e = binary(int(1), BinaryOp::Greater, int(2));
+        assert_eq!(fold(&e), Some(ConstValue::Bool(false)));
+    }
+
+    #[test]
+    fn bails_on_int_overflow_and_zero_division() {
+        let e = binary(int(i64::MAX), BinaryOp::Add, int(1));
+        assert_eq!(fold(&e), None);
+        let e = binary(int(i64::MIN), BinaryOp::Divide, int(-1));
+        assert_eq!(fold(&e), None);
+        let e = binary(int(10), BinaryOp::Divide, int(0));
+        assert_eq!(fold(&e), None);
+        let e = binary(int(10), BinaryOp::Modulo, int(0));
+        assert_eq!(fold(&e), None);
+    }
+
+    #[test]
+    fn bails_on_exponent() {
+        let e = binary(int(2), BinaryOp::Exponent, int(3));
+        assert_eq!(fold(&e), None);
+    }
+
+    #[test]
+    fn folds_float_ops_and_bails_on_nan() {
+        use ordered_float::OrderedFloat;
+        let f = |v: f64| lit(LiteralNode::Float(OrderedFloat(v)));
+        let e = binary(f(1.0), BinaryOp::NotEqual, f(0.0));
+        assert_eq!(fold(&e), Some(ConstValue::Bool(true)));
+        // 0.0 / 0.0 is NaN: the folder must stay silent.
+        let e = binary(f(0.0), BinaryOp::Divide, f(0.0));
+        assert_eq!(fold(&e), None);
+        // float / 0.0 is inf at runtime, not a panic; folding keeps that value.
+        let e = binary(f(1.0), BinaryOp::Divide, f(0.0));
+        assert_eq!(fold(&e), Some(ConstValue::Float(f64::INFINITY)));
+    }
+
+    #[test]
+    fn folds_logical_string_char_ops() {
+        let e = binary(lit(true.into()), BinaryOp::LogicalAnd, lit(false.into()));
+        assert_eq!(fold(&e), Some(ConstValue::Bool(false)));
+        let e = binary(lit("a".into()), BinaryOp::Add, lit("b".into()));
+        assert_eq!(fold(&e), Some(ConstValue::Str("ab".to_string())));
+        let e = binary(lit('x'.into()), BinaryOp::Equal, lit('x'.into()));
+        assert_eq!(fold(&e), Some(ConstValue::Bool(true)));
+    }
+
+    #[test]
+    fn folds_unary_and_env_identifiers() {
+        let e = unary(UnaryOp::Neg, int(5));
+        assert_eq!(fold(&e), Some(ConstValue::Int(-5)));
+        let e = unary(UnaryOp::Not, lit(true.into()));
+        assert_eq!(fold(&e), Some(ConstValue::Bool(false)));
+
+        let mut env = HashMap::new();
+        env.insert("b".to_string(), ConstValue::Int(0));
+        let e = binary(ident("b"), BinaryOp::NotEqual, int(0));
+        assert_eq!(fold_with_env(&e, &env), Some(ConstValue::Bool(false)));
+        // Unknown identifiers poison the whole fold.
+        let e = binary(ident("unknown"), BinaryOp::NotEqual, int(0));
+        assert_eq!(fold_with_env(&e, &env), None);
+    }
+}

--- a/mux-compiler/src/semantics/expressions.rs
+++ b/mux-compiler/src/semantics/expressions.rs
@@ -18,11 +18,28 @@ impl SemanticAnalyzer {
             ExpressionKind::Identifier(name) => self.analyze_identifier_expr(name, expr),
             ExpressionKind::Literal(_) => Ok(()),
             ExpressionKind::None => Ok(()),
-            ExpressionKind::Binary { left, right, .. } => {
-                self.analyze_expression(left)?;
+            ExpressionKind::Binary {
+                left,
+                op,
+                op_span,
+                right,
+            } => {
+                // List writes wrap negative indices and extend past the end,
+                // so an assignment target is exempt from the provable
+                // out-of-bounds check that applies to reads.
+                if op.is_assignment()
+                    && let ExpressionKind::ListAccess {
+                        expr: target,
+                        index,
+                    } = &left.kind
+                {
+                    self.analyze_list_access_expr(target, index, true)?;
+                } else {
+                    self.analyze_expression(left)?;
+                }
                 self.analyze_expression(right)?;
                 let _ = self.get_expression_type(expr)?;
-                Ok(())
+                self.check_const_binary(left, op, op_span, right)
             }
             ExpressionKind::Unary {
                 expr,
@@ -37,7 +54,7 @@ impl SemanticAnalyzer {
                 Ok(())
             }
             ExpressionKind::ListAccess { expr, index } => {
-                self.analyze_list_access_expr(expr, index)
+                self.analyze_list_access_expr(expr, index, false)
             }
             ExpressionKind::ListLiteral(elements) => self.analyze_list_literal_expr(elements),
             ExpressionKind::MapLiteral { entries, .. } => {
@@ -267,7 +284,7 @@ impl SemanticAnalyzer {
         }
 
         let _ = self.get_expression_type(expr)?;
-        Ok(())
+        self.check_call_preconditions(expr, func, args)
     }
 
     fn check_some_call_args(
@@ -297,6 +314,7 @@ impl SemanticAnalyzer {
         &mut self,
         expr: &ExpressionNode,
         index: &ExpressionNode,
+        is_assignment_target: bool,
     ) -> Result<(), SemanticError> {
         self.analyze_expression(expr)?;
         self.analyze_expression(index)?;
@@ -346,7 +364,10 @@ impl SemanticAnalyzer {
                 ));
             }
         }
-        Ok(())
+        if is_assignment_target {
+            return Ok(());
+        }
+        self.check_const_index(expr, &target_type, index)
     }
 
     fn analyze_list_literal_expr(

--- a/mux-compiler/src/semantics/mod.rs
+++ b/mux-compiler/src/semantics/mod.rs
@@ -1,5 +1,7 @@
 // Module declarations
 
+pub mod const_checks;
+pub mod const_fold;
 pub mod declarations;
 pub mod error;
 pub mod expressions;
@@ -74,6 +76,13 @@ pub struct SemanticAnalyzer {
     // must enforce at entry (one entry per declaring interface).
     pub(super) inherited_preconditions:
         HashMap<String, HashMap<String, Vec<where_clause::InheritedPrecondition>>>,
+    // (class name or "" for free functions, name) -> where preconditions,
+    // collected before the analysis pass so call sites can prove violations
+    // from literal arguments regardless of declaration order.
+    pub(super) function_preconditions: HashMap<(String, String), const_checks::WherePreconditions>,
+    // (enum name, variant name) -> where preconditions on the variant payload.
+    pub(super) enum_variant_preconditions:
+        HashMap<(String, String), const_checks::EnumVariantPreconditions>,
 }
 
 impl Default for SemanticAnalyzer {
@@ -111,6 +120,8 @@ impl SemanticAnalyzer {
             class_invariants: HashMap::new(),
             interface_preconditions: HashMap::new(),
             inherited_preconditions: HashMap::new(),
+            function_preconditions: HashMap::new(),
+            enum_variant_preconditions: HashMap::new(),
         }
     }
 
@@ -258,6 +269,8 @@ impl SemanticAnalyzer {
             class_invariants: HashMap::new(),
             interface_preconditions: HashMap::new(),
             inherited_preconditions: HashMap::new(),
+            function_preconditions: HashMap::new(),
+            enum_variant_preconditions: HashMap::new(),
         }
     }
 
@@ -595,6 +608,7 @@ impl SemanticAnalyzer {
         // Imports are loaded by now, so interface where-clauses from every
         // module are visible for classes to inherit during analysis.
         self.collect_interface_preconditions(ast);
+        self.collect_where_preconditions(ast);
         self.analyze_nodes(ast, files);
         std::mem::take(&mut self.errors)
     }

--- a/mux-compiler/src/semantics/where_clause.rs
+++ b/mux-compiler/src/semantics/where_clause.rs
@@ -7,6 +7,7 @@
 //! the fields each references) and interface method preconditions that every
 //! implementing class must enforce.
 
+use super::const_fold::{self, ConstValue};
 use super::{SemanticAnalyzer, SemanticError, SymbolKind, Type, format_type};
 use crate::ast::{
     AstNode, EnumVariant, ExpressionKind, ExpressionNode, Field, FunctionNode, PrimitiveType,
@@ -42,7 +43,15 @@ impl SemanticAnalyzer {
                 continue;
             }
             match self.get_expression_type(predicate) {
-                Ok(Type::Primitive(PrimitiveType::Bool)) => {}
+                Ok(Type::Primitive(PrimitiveType::Bool)) => {
+                    if const_fold::fold(predicate) == Some(ConstValue::Bool(false)) {
+                        self.errors.push(SemanticError::with_help(
+                            "where predicate is always false",
+                            predicate.span,
+                            "This predicate can never hold, so every check of it would panic. Fix the condition or remove it.",
+                        ));
+                    }
+                }
                 Ok(other) => self.errors.push(SemanticError::with_help(
                     format!(
                         "where predicate must be a bool, got {}",
@@ -183,6 +192,7 @@ impl SemanticAnalyzer {
             );
         }
 
+        let construction_env = self.fold_field_defaults(fields);
         let mut invariants = Vec::new();
         let clauses = fields
             .iter()
@@ -191,6 +201,19 @@ impl SemanticAnalyzer {
         for clause in clauses {
             self.analyze_where_clause(clause);
             for predicate in &clause.predicates {
+                // Invariants run at .new() right after defaults are applied,
+                // so defaults that violate one make every construction panic.
+                // Context-free false predicates are already reported above.
+                if const_fold::fold(predicate) != Some(ConstValue::Bool(false))
+                    && const_fold::fold_with_env(predicate, &construction_env)
+                        == Some(ConstValue::Bool(false))
+                {
+                    self.errors.push(SemanticError::with_help(
+                        "field defaults violate this where constraint at construction",
+                        predicate.span,
+                        "Invariants are checked when .new() runs, after field defaults are applied, so every construction would panic. Give the constrained fields defaults that satisfy this predicate.",
+                    ));
+                }
                 invariants.push(ClassInvariant {
                     referenced_fields: referenced_field_names(predicate, &field_names),
                     predicate: predicate.clone(),
@@ -205,6 +228,35 @@ impl SemanticAnalyzer {
 
         self.record_inherited_preconditions(name, methods, traits);
         Ok(())
+    }
+
+    /// The constant value each field holds right after `.new()` applies
+    /// defaults: the folded explicit default, or the zero value codegen
+    /// stores for primitive fields without one. Fields whose construction
+    /// value is not a provable constant are left out, which makes any
+    /// invariant that references them fold to `None` and stay silent.
+    fn fold_field_defaults(&self, fields: &[Field]) -> HashMap<String, ConstValue> {
+        let mut env = HashMap::new();
+        for field in fields {
+            if field.is_generic_param {
+                continue;
+            }
+            let value = if let Some(default) = &field.default_value {
+                const_fold::fold(default)
+            } else {
+                match self.resolve_type(&field.type_) {
+                    Ok(Type::Primitive(PrimitiveType::Int)) => Some(ConstValue::Int(0)),
+                    Ok(Type::Primitive(PrimitiveType::Float)) => Some(ConstValue::Float(0.0)),
+                    Ok(Type::Primitive(PrimitiveType::Bool)) => Some(ConstValue::Bool(false)),
+                    Ok(Type::Primitive(PrimitiveType::Str)) => Some(ConstValue::Str(String::new())),
+                    _ => None,
+                }
+            };
+            if let Some(value) = value {
+                env.insert(field.name.clone(), value);
+            }
+        }
+        env
     }
 
     /// For each interface the class implements, record the preconditions of

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_where_new.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__runtime_where_new.snap
@@ -3,4 +3,4 @@ source: mux-compiler/tests/executable_integration.rs
 expression: normalized
 ---
 panic: where constraint violated
---> runtime_where_new.mux:5:25
+--> runtime_where_new.mux:7:29

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_div_by_zero_literal.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_div_by_zero_literal.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: division by zero
+--> test_scripts/error_cases/semantic_div_by_zero_literal.mux:4:13
+   |
+ 4 | print((10 / 0).to_string())
+   |             ^
+   |
+= help: The divisor is always zero, so this operation would panic on every execution

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_list_index_negative.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_list_index_negative.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: list index out of bounds: index -1
+--> test_scripts/error_cases/semantic_list_index_negative.mux:5:12
+   |
+ 5 | print(nums[-1].to_string())
+   |            ^^
+   |
+= help: List indices start at 0; a negative index panics on every execution

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_list_index_oob.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_list_index_oob.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: list index out of bounds: index 5, length 3
+--> test_scripts/error_cases/semantic_list_index_oob.mux:4:17
+   |
+ 4 | print([1, 2, 3][5].to_string())
+   |                 ^
+   |
+= help: The index is always outside this list, so the access would panic on every execution

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_map_key_not_found.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_map_key_not_found.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: key not found in map: key c
+--> test_scripts/error_cases/semantic_map_key_not_found.mux:4:24
+   |
+ 4 | print({"a": 1, "b": 2}["c"].to_string())
+   |                        ^^^
+   |
+= help: The key is never present in this map literal, so the lookup would panic on every execution

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_mod_by_zero_literal.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_mod_by_zero_literal.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: modulo by zero
+--> test_scripts/error_cases/semantic_mod_by_zero_literal.mux:4:13
+   |
+ 4 | print((10 % 0).to_string())
+   |             ^
+   |
+= help: The divisor is always zero, so this operation would panic on every execution

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_always_false.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_always_false.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: where predicate is always false
+--> test_scripts/error_cases/semantic_where_always_false.mux:4:23
+   |
+ 4 | func f(int a) where { 1 > 2 } returns int {
+   |                       ^^^^^
+   |
+= help: This predicate can never hold, so every check of it would panic. Fix the condition or remove it.

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_assign_violation.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_assign_violation.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: assignment violates where constraint of 'Port.number'
+--> test_scripts/error_cases/semantic_where_assign_violation.mux:9:12
+   |
+ 9 | p.number = 70000
+   |            ^^^^^
+   |
+= help: The where predicate at 5:41 is always false for this value, so this assignment would panic on every execution

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_call_violation.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_call_violation.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: arguments to 'divide' violate its where constraint
+--> test_scripts/error_cases/semantic_where_call_violation.mux:8:7
+   |
+ 8 | print(divide(10.0, 0.0).to_string())
+   |       ^^^^^^
+   |
+= help: The where predicate at 4:39 is always false for these argument values, so this call would panic on every execution

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_default_violation.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_default_violation.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: field defaults violate this where constraint at construction
+--> test_scripts/error_cases/semantic_where_default_violation.mux:5:25
+   |
+ 5 |     int balance where { balance >= 100 }
+   |                         ^^^^^^^^^^^^^^
+   |
+= help: Invariants are checked when .new() runs, after field defaults are applied, so every construction would panic. Give the constrained fields defaults that satisfy this predicate.

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_enum_violation.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_enum_violation.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: arguments to 'Status.Code' violate its where constraint
+--> test_scripts/error_cases/semantic_where_enum_violation.mux:9:12
+   |
+ 9 | auto bad = Status.Code(9999)
+   |            ^^^^^^^^^^^
+   |
+= help: The where predicate at 6:43 is always false for these argument values, so this call would panic on every execution

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_inherited_violation.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__semantic_where_inherited_violation.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: arguments to 'Calc.div' violate its where constraint
+--> test_scripts/error_cases/semantic_where_inherited_violation.mux:17:7
+   |
+17 | print(c.div(0).to_string())
+   |       ^^^^^
+   |
+= help: The where predicate at 5:29 is always false for these argument values, so this call would panic on every execution

--- a/test_scripts/error_cases/runtime_where_enum_variant.mux
+++ b/test_scripts/error_cases/runtime_where_enum_variant.mux
@@ -5,5 +5,6 @@ enum Status {
     Code(int value) where { value >= 100, value <= 599 }
 }
 
-auto bad = Status.Code(9999)
+int bad_code = 9999
+auto bad = Status.Code(bad_code)
 print("unreachable")

--- a/test_scripts/error_cases/runtime_where_field.mux
+++ b/test_scripts/error_cases/runtime_where_field.mux
@@ -5,5 +5,6 @@ class Port {
 }
 
 auto p = Port.new()
-p.number = 70000
+int too_big = 70000
+p.number = too_big
 print("unreachable")

--- a/test_scripts/error_cases/runtime_where_function.mux
+++ b/test_scripts/error_cases/runtime_where_function.mux
@@ -8,4 +8,5 @@ func divide(float a, float b)
     return a / b
 }
 
-print(divide(1.0, 0.0).to_string())
+float zero = 0.0
+print(divide(1.0, zero).to_string())

--- a/test_scripts/error_cases/runtime_where_new.mux
+++ b/test_scripts/error_cases/runtime_where_new.mux
@@ -1,9 +1,11 @@
-// Constructing an object whose field default violates its where constraint
-// panics at .new(): objects must be born satisfying their invariants.
+// Constructing an object whose defaults violate an invariant panics at
+// .new(): objects must be born satisfying their invariants. The predicate
+// calls a method, so the violation is not provable at compile time and the
+// runtime check is the enforcement point.
 
-class Account {
-    int balance where { balance >= 100 }
+class Batch {
+    list<int> items where { items.size() > 0 }
 }
 
-auto a = Account.new()
+auto b = Batch.new()
 print("unreachable")

--- a/test_scripts/error_cases/semantic_div_by_zero_literal.mux
+++ b/test_scripts/error_cases/semantic_div_by_zero_literal.mux
@@ -1,0 +1,4 @@
+// Integer division by a literal zero is a guaranteed panic, so it is
+// rejected at compile time.
+
+print((10 / 0).to_string())

--- a/test_scripts/error_cases/semantic_list_index_negative.mux
+++ b/test_scripts/error_cases/semantic_list_index_negative.mux
@@ -1,0 +1,5 @@
+// A literal negative index is outside any list, so it is rejected at
+// compile time instead of panicking on every execution.
+
+auto nums = [1, 2, 3]
+print(nums[-1].to_string())

--- a/test_scripts/error_cases/semantic_list_index_oob.mux
+++ b/test_scripts/error_cases/semantic_list_index_oob.mux
@@ -1,0 +1,4 @@
+// A literal index past the end of a list literal is a guaranteed panic, so
+// it is rejected at compile time.
+
+print([1, 2, 3][5].to_string())

--- a/test_scripts/error_cases/semantic_map_key_not_found.mux
+++ b/test_scripts/error_cases/semantic_map_key_not_found.mux
@@ -1,0 +1,4 @@
+// Looking up a literal key that is provably absent from a map literal is a
+// guaranteed panic, so it is rejected at compile time.
+
+print({"a": 1, "b": 2}["c"].to_string())

--- a/test_scripts/error_cases/semantic_mod_by_zero_literal.mux
+++ b/test_scripts/error_cases/semantic_mod_by_zero_literal.mux
@@ -1,0 +1,4 @@
+// Integer modulo by a literal zero is a guaranteed panic, so it is
+// rejected at compile time.
+
+print((10 % 0).to_string())

--- a/test_scripts/error_cases/semantic_where_always_false.mux
+++ b/test_scripts/error_cases/semantic_where_always_false.mux
@@ -1,0 +1,8 @@
+// A predicate that folds to false from literals alone can never hold and is
+// rejected at compile time instead of panicking on every call.
+
+func f(int a) where { 1 > 2 } returns int {
+    return a
+}
+
+print(f(1).to_string())

--- a/test_scripts/error_cases/semantic_where_assign_violation.mux
+++ b/test_scripts/error_cases/semantic_where_assign_violation.mux
@@ -1,0 +1,10 @@
+// A literal assigned to a constrained field that violates its where clause
+// is a guaranteed panic, so the assignment is rejected at compile time.
+
+class Port {
+    int number = 80 where { number > 0, number < 65535 }
+}
+
+auto p = Port.new()
+p.number = 70000
+print("unreachable")

--- a/test_scripts/error_cases/semantic_where_call_violation.mux
+++ b/test_scripts/error_cases/semantic_where_call_violation.mux
@@ -1,0 +1,8 @@
+// Literal arguments that violate a callee's where precondition are a
+// guaranteed panic, so the call is rejected at compile time.
+
+func divide(float a, float b) where { b != 0.0 } returns float {
+    return a / b
+}
+
+print(divide(10.0, 0.0).to_string())

--- a/test_scripts/error_cases/semantic_where_default_violation.mux
+++ b/test_scripts/error_cases/semantic_where_default_violation.mux
@@ -1,0 +1,9 @@
+// Invariants are checked at .new() after defaults are applied, so defaults
+// that violate one make every construction panic; rejected at compile time.
+
+class Account {
+    int balance where { balance >= 100 }
+}
+
+auto a = Account.new()
+print("unreachable")

--- a/test_scripts/error_cases/semantic_where_enum_violation.mux
+++ b/test_scripts/error_cases/semantic_where_enum_violation.mux
@@ -1,0 +1,10 @@
+// A literal payload that violates an enum variant's where clause is a
+// guaranteed panic, so the construction is rejected at compile time.
+
+enum Status {
+    Unknown,
+    Code(int value) where { value >= 100, value <= 599 }
+}
+
+auto bad = Status.Code(9999)
+print("unreachable")

--- a/test_scripts/error_cases/semantic_where_inherited_violation.mux
+++ b/test_scripts/error_cases/semantic_where_inherited_violation.mux
@@ -1,5 +1,5 @@
-// An implementer enforces the interface method's where precondition even
-// though its own parameter is named differently.
+// A literal argument violating a precondition inherited from an interface
+// method is a guaranteed panic, so the call is rejected at compile time.
 
 interface Divider {
     func div(int n) where { n != 0 } returns int
@@ -14,5 +14,4 @@ class Calc is Divider {
 }
 
 auto c = Calc.new()
-int zero = 0
-print(c.div(zero).to_string())
+print(c.div(0).to_string())


### PR DESCRIPTION
## Summary

Closes #236.

Adds a constant folder and a family of zero-false-positive checks that reject programs guaranteed to panic at runtime. The rule throughout: a check fires only when the violation is provable from literals alone; anything unknown folds to `None` and the existing **runtime check stays the enforcement point** (Mux has no warning level, so silence is the only safe fallback).

## The folder (`semantics/const_fold.rs`)

Pure `fold` / `fold_with_env` mirroring runtime semantics exactly:
- checked integer arithmetic (overflow, `MIN / -1`, division by zero all bail - the folder never guesses wrap behavior)
- IEEE float arithmetic, bailing on NaN results so NaN comparison semantics never need mirroring (`x / 0.0` folds to `inf`, matching the runtime's non-panicking behavior)
- bool/string/char comparisons, string concat, logical and/or **without short-circuit** - both sides must fold, so codegen skipping a fold-true predicate can never drop an evaluation
- `Exponent` (runtime lowering) and everything else: bail

Unit-tested inline (overflow/NaN/zero-division bail, env binding, unknown identifiers poison the fold).

## Rejected at compile time

| Check | Example |
|---|---|
| always-false where predicate | `where { 1 > 2 }` |
| call args violating preconditions (functions, methods, enum variants, **inherited interface preconditions**) | `divide(10.0, 0.0)`, `Status.Code(9999)`, `calc.div(0)` |
| field defaults violating invariants at `.new()` | `int balance where { balance >= 100 }` (zero-init 0) |
| literal field assignment violating a single-field invariant | `p.number = 70000` |
| int division/modulo by literal zero | `10 / 0`, `10 % 0` |
| provably out-of-bounds list **reads** | `nums[-1]`, `[1,2,3][5]` |
| literal key absent from a map literal | `{"a": 1}["b"]` |

Per-call/per-assignment errors point at the call site with the predicate's location in the help text; a context-free false predicate is reported once at its declaration, not repeated per call site.

## Notable correctness decisions

- **List writes are exempt** from the index check: `mux_list_set_value` wraps negative indices and extends past the end, so `wrap_list[-1] = 999` never panics (caught by `collections.mux` during development - the check now applies to reads only).
- Cross-module function-name collisions **poison** the preconditions entry entirely rather than risk checking against the wrong callee.
- Codegen skips where predicates that fold to true (no branch emitted); fold-false predicates still emit normally.
- Multi-field invariants (`width <= height`) are never checked on single-field assignment - other fields are unknown state.
- Float map keys are excluded from the key check.

## Tests

- 11 new `semantic_*` error cases + snapshots + error-corpus entries (append-only)
- 5 `runtime_where_*` scripts whose violations became provable now route the value through a variable, keeping the runtime path covered; `runtime_where_new` now uses a method-call predicate (`items.size() > 0`) that is not foldable
- `where_clauses.mux` (all-satisfying literals) passes unchanged - exercises the no-false-positive property and the fold-true codegen skip
- Full `cargo test` green (12 suites), clippy `-D warnings` clean, fmt clean

**Snapshots to review**: new executable snapshots for the 11 semantic cases, updated locations for the reworked runtime cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)