### PR TITLE
Add targeted diagnostic for range literal syntax (digit followed by ..)

### DIFF
--- a/docs/error-corpus/lexer.json
+++ b/docs/error-corpus/lexer.json
@@ -30,5 +30,13 @@
     "help": "Make sure to close the block comment with '*/'",
     "category": "lexer",
     "relevant_docs": []
+  },
+  {
+    "id": "lexer_range_literal",
+    "source": "for int i in 0..10 {}",
+    "error": "Mux does not have range literal syntax",
+    "help": "Use range(a, b) to iterate over a numeric range, e.g. for int i in range(0, 10)",
+    "category": "lexer",
+    "relevant_docs": ["/docs/reference/lexical-structure/", "/docs/language-guide/control-flow/"]
   }
 ]

--- a/mux-compiler/src/lexer/mod.rs
+++ b/mux-compiler/src/lexer/mod.rs
@@ -334,6 +334,12 @@ impl<'a> Lexer<'a> {
             *is_float = true;
         } else if after_dot.is_some_and(|c| c.is_ascii_alphabetic() || c == '_') {
             return Ok(());
+        } else if after_dot == Some('.') {
+            return Err(LexerError::with_help(
+                "Mux does not have range literal syntax",
+                Span::new(self.source.line, self.source.col),
+                "Use range(a, b) to iterate over a numeric range, e.g. for int i in range(0, 10)",
+            ));
         } else {
             return Err(LexerError::new(
                 "Expected digit after decimal point",
@@ -1001,6 +1007,17 @@ auto y = 42"#;
             result.is_err(),
             "Expected error for invalid integer literal"
         );
+    }
+
+    #[test]
+    fn test_range_literal_diagnostic() {
+        // Mux has no range literal syntax; `0..10` should produce a targeted
+        // diagnostic pointing users at range(a, b) instead of the generic
+        // "Expected digit after decimal point" message.
+        let input = "for int i in 0..10 {}";
+        let mut source = Source::from_test_str(input);
+        let result = Lexer::new(&mut source).lex_all();
+        assert_lexer_error(result, "Mux does not have range literal syntax", 1, 15);
     }
 
     #[test]

--- a/mux-compiler/tests/snapshots/executable_integration__executable_integration__lexer_range_literal.snap
+++ b/mux-compiler/tests/snapshots/executable_integration__executable_integration__lexer_range_literal.snap
@@ -1,0 +1,11 @@
+---
+source: mux-compiler/tests/executable_integration.rs
+expression: normalized
+---
+error: Mux does not have range literal syntax
+--> test_scripts/error_cases/lexer_range_literal.mux:2:15
+   |
+ 2 | for int i in 0..10 {
+   |               ^
+   |
+= help: Use range(a, b) to iterate over a numeric range, e.g. for int i in range(0, 10)

--- a/test_scripts/error_cases/lexer_range_literal.mux
+++ b/test_scripts/error_cases/lexer_range_literal.mux
@@ -1,0 +1,4 @@
+// Should fail: Mux does not have range literal syntax
+for int i in 0..10 {
+    print(i.to_string())
+}


### PR DESCRIPTION
## Summary

`for i in 0..10` previously failed with a misleading lexer error, "Expected digit after decimal point", pointing at the first dot. The user did not mistype a float - they attempted a range literal, which Mux does not have (ranges are written as `range(a, b)`).

This adds a targeted diagnostic in `consume_fraction_if_present`: when a digit is immediately followed by `..`, the lexer now reports:

```
error: Mux does not have range literal syntax
--> test_scripts/error_cases/lexer_range_literal.mux:2:15
   |
 2 | for int i in 0..10 {
   |               ^
   |
= help: Use range(a, b) to iterate over a numeric range, e.g. for int i in range(0, 10)
```

## Motivation

muxlang/tree-sitter-mux#8 - its validation file used `0..10` because the existing error message never explained that Mux has no range syntax or what to use instead.

## Changes

- `mux-compiler/src/lexer/mod.rs`: new `after_dot == Some('.')` case before the generic "Expected digit after decimal point" error, using the existing `LexerError::with_help` pattern; plus a unit test (`test_range_literal_diagnostic`).
- `test_scripts/error_cases/lexer_range_literal.mux`: new error case exercising `for int i in 0..10`, with its executable integration snapshot.
- `docs/error-corpus/lexer.json`: registered the new diagnostic in the error corpus.

## Testing

- `./scripts/run-checks.sh` (build, clippy with `-D warnings`, full test suite) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)