### PR TITLE
chore(deps): bump cmov 0.5.3 -> 0.5.4 (GHSA-3rjw-m598-pq24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"

--- a/mux-compiler/fuzz/Cargo.lock
+++ b/mux-compiler/fuzz/Cargo.lock
@@ -264,9 +264,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"


### PR DESCRIPTION
## What

Bumps `cmov` from 0.5.3 to 0.5.4 in both lockfiles Dependabot flagged:
- root `Cargo.lock` (alert #54)
- `mux-compiler/fuzz/Cargo.lock` (alert #55)

## Why

`cmov < 0.5.4` can produce wrong results for `Cmov`/`CmovEq` on aarch64 when the high bits of the input registers are set (**GHSA-3rjw-m598-pq24**, medium). `cmov` is a transitive dependency via the postgres crypto stack:

```
cmov -> ctutils -> digest -> hmac/md-5/sha2 -> postgres-protocol -> ... -> mux-runtime -> mux-lang
```

## Scope

Lockfile-only patch bump - no manifest or source changes. The fuzz lockfile was edited surgically (version + checksum only) to avoid dragging in unrelated stale-lock churn; the root lock was updated via `cargo update -p cmov --precise 0.5.4`. Closes both Dependabot alerts on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)