### PR TITLE
ci: post valgrind & benchmark reports as PR comments (fork-safe)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,34 +186,13 @@ jobs:
         run: |
           set -o pipefail
           ./scripts/valgrind-checks.sh 2>&1 | tee valgrind.log
-      - name: Build PR comment payload
-        if: ${{ always() && github.event_name == 'pull_request' }}
-        env:
-          TITLE: "Valgrind Memory Checks"
-          OUTCOME: ${{ steps.run.outcome }}
-          LOG: valgrind.log
-          SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          mkdir -p pr-comment
-          if [ "$OUTCOME" = "success" ]; then status="PASSED"; else status="FAILED"; fi
-          # Neutralize any ``` in untrusted output so a hostile PR can't break
-          # out of the code fence and inject markdown into the posted comment.
-          sanitized="$(sed 's/```/`\xE2\x80\x8b``/g' "$LOG" 2>/dev/null | tail -n 300)"
-          {
-            printf '## %s - %s\n\n' "$TITLE" "$status"
-            printf '<details><summary>Output (last 300 lines)</summary>\n\n'
-            printf '```text\n'
-            printf '%s\n' "${sanitized:-(no output captured)}"
-            printf '```\n\n</details>\n\n'
-            printf '_Commit `%s` - [full run](%s)_\n' "$SHA" "$RUN_URL"
-          } > pr-comment/report.md
-      - name: Upload PR comment payload
+      - name: Upload valgrind log for PR comment
+        # Raw log only; the trusted pr-comment workflow escapes and renders it.
         if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: pr-comment-valgrind
-          path: pr-comment/
+          path: valgrind.log
           if-no-files-found: warn
   benchmarks:
     name: Benchmarks (report-only)
@@ -288,33 +267,13 @@ jobs:
             target/bench-report/
             target/criterion/
           if-no-files-found: warn
-      - name: Build PR comment payload
-        if: ${{ always() && github.event_name == 'pull_request' }}
-        env:
-          TITLE: "Benchmarks (report-only)"
-          OUTCOME: ${{ steps.run.outcome }}
-          LOG: bench.log
-          SHA: ${{ github.event.pull_request.head.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          mkdir -p pr-comment
-          if [ "$OUTCOME" = "success" ]; then status="completed"; else status="errored"; fi
-          sanitized="$(sed 's/```/`\xE2\x80\x8b``/g' "$LOG" 2>/dev/null | tail -n 300)"
-          {
-            printf '## %s - %s\n\n' "$TITLE" "$status"
-            printf '_Informational only - shared runners are too noisy to gate on. Full per-phase distribution is in the `benchmark-report` artifact._\n\n'
-            printf '<details><summary>Output (last 300 lines)</summary>\n\n'
-            printf '```text\n'
-            printf '%s\n' "${sanitized:-(no output captured)}"
-            printf '```\n\n</details>\n\n'
-            printf '_Commit `%s` - [full run](%s)_\n' "$SHA" "$RUN_URL"
-          } > pr-comment/report.md
-      - name: Upload PR comment payload
+      - name: Upload benchmark log for PR comment
+        # Raw log only; the trusted pr-comment workflow escapes and renders it.
         if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: pr-comment-benchmarks
-          path: pr-comment/
+          path: bench.log
           if-no-files-found: warn
   sonarqube:
     name: SonarQube

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,41 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Valgrind checks
-        run: ./scripts/valgrind-checks.sh
+        id: run
+        run: |
+          set -o pipefail
+          ./scripts/valgrind-checks.sh 2>&1 | tee valgrind.log
+      - name: Build PR comment payload
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        env:
+          TITLE: "Valgrind Memory Checks"
+          OUTCOME: ${{ steps.run.outcome }}
+          LOG: valgrind.log
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          mkdir -p pr-comment
+          if [ "$OUTCOME" = "success" ]; then status="✅ passed"; else status="❌ failed"; fi
+          # Neutralize any ``` in untrusted output so a hostile PR can't break
+          # out of the code fence and inject markdown into the posted comment.
+          sanitized="$(sed 's/```/`\xE2\x80\x8b``/g' "$LOG" 2>/dev/null | tail -n 300)"
+          {
+            printf '## %s — %s\n\n' "$TITLE" "$status"
+            printf '<details><summary>Output (last 300 lines)</summary>\n\n'
+            printf '```text\n'
+            printf '%s\n' "${sanitized:-(no output captured)}"
+            printf '```\n\n</details>\n\n'
+            printf '_Commit `%s` • [full run](%s)_\n' "$SHA" "$RUN_URL"
+          } > pr-comment/report.md
+          printf '%s' "$PR" > pr-comment/pr-number.txt
+      - name: Upload PR comment payload
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-comment-valgrind
+          path: pr-comment/
+          if-no-files-found: warn
   benchmarks:
     name: Benchmarks (report-only)
     needs: detect-changes
@@ -242,7 +276,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Run benchmarks
-        run: cargo bench -p mux-lang
+        id: run
+        run: |
+          set -o pipefail
+          cargo bench -p mux-lang 2>&1 | tee bench.log
       - name: Build per-phase distribution report
         run: python3 scripts/bench-report.py
       - name: Upload benchmark report
@@ -252,6 +289,36 @@ jobs:
           path: |
             target/bench-report/
             target/criterion/
+          if-no-files-found: warn
+      - name: Build PR comment payload
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        env:
+          TITLE: "Benchmarks (report-only)"
+          OUTCOME: ${{ steps.run.outcome }}
+          LOG: bench.log
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          mkdir -p pr-comment
+          if [ "$OUTCOME" = "success" ]; then status="✅ completed"; else status="⚠️ errored"; fi
+          sanitized="$(sed 's/```/`\xE2\x80\x8b``/g' "$LOG" 2>/dev/null | tail -n 300)"
+          {
+            printf '## %s — %s\n\n' "$TITLE" "$status"
+            printf '_Informational only — shared runners are too noisy to gate on. Full per-phase distribution is in the `benchmark-report` artifact._\n\n'
+            printf '<details><summary>Output (last 300 lines)</summary>\n\n'
+            printf '```text\n'
+            printf '%s\n' "${sanitized:-(no output captured)}"
+            printf '```\n\n</details>\n\n'
+            printf '_Commit `%s` • [full run](%s)_\n' "$SHA" "$RUN_URL"
+          } > pr-comment/report.md
+          printf '%s' "$PR" > pr-comment/pr-number.txt
+      - name: Upload PR comment payload
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-comment-benchmarks
+          path: pr-comment/
           if-no-files-found: warn
   sonarqube:
     name: SonarQube

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,24 +192,22 @@ jobs:
           TITLE: "Valgrind Memory Checks"
           OUTCOME: ${{ steps.run.outcome }}
           LOG: valgrind.log
-          PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           mkdir -p pr-comment
-          if [ "$OUTCOME" = "success" ]; then status="✅ passed"; else status="❌ failed"; fi
+          if [ "$OUTCOME" = "success" ]; then status="PASSED"; else status="FAILED"; fi
           # Neutralize any ``` in untrusted output so a hostile PR can't break
           # out of the code fence and inject markdown into the posted comment.
           sanitized="$(sed 's/```/`\xE2\x80\x8b``/g' "$LOG" 2>/dev/null | tail -n 300)"
           {
-            printf '## %s — %s\n\n' "$TITLE" "$status"
+            printf '## %s - %s\n\n' "$TITLE" "$status"
             printf '<details><summary>Output (last 300 lines)</summary>\n\n'
             printf '```text\n'
             printf '%s\n' "${sanitized:-(no output captured)}"
             printf '```\n\n</details>\n\n'
-            printf '_Commit `%s` • [full run](%s)_\n' "$SHA" "$RUN_URL"
+            printf '_Commit `%s` - [full run](%s)_\n' "$SHA" "$RUN_URL"
           } > pr-comment/report.md
-          printf '%s' "$PR" > pr-comment/pr-number.txt
       - name: Upload PR comment payload
         if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
@@ -296,23 +294,21 @@ jobs:
           TITLE: "Benchmarks (report-only)"
           OUTCOME: ${{ steps.run.outcome }}
           LOG: bench.log
-          PR: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           mkdir -p pr-comment
-          if [ "$OUTCOME" = "success" ]; then status="✅ completed"; else status="⚠️ errored"; fi
+          if [ "$OUTCOME" = "success" ]; then status="completed"; else status="errored"; fi
           sanitized="$(sed 's/```/`\xE2\x80\x8b``/g' "$LOG" 2>/dev/null | tail -n 300)"
           {
-            printf '## %s — %s\n\n' "$TITLE" "$status"
-            printf '_Informational only — shared runners are too noisy to gate on. Full per-phase distribution is in the `benchmark-report` artifact._\n\n'
+            printf '## %s - %s\n\n' "$TITLE" "$status"
+            printf '_Informational only - shared runners are too noisy to gate on. Full per-phase distribution is in the `benchmark-report` artifact._\n\n'
             printf '<details><summary>Output (last 300 lines)</summary>\n\n'
             printf '```text\n'
             printf '%s\n' "${sanitized:-(no output captured)}"
             printf '```\n\n</details>\n\n'
-            printf '_Commit `%s` • [full run](%s)_\n' "$SHA" "$RUN_URL"
+            printf '_Commit `%s` - [full run](%s)_\n' "$SHA" "$RUN_URL"
           } > pr-comment/report.md
-          printf '%s' "$PR" > pr-comment/pr-number.txt
       - name: Upload PR comment payload
         if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -121,18 +121,25 @@ jobs:
             else
               status="report-only"
             fi
-            # Neutralize any ``` in the untrusted log so it cannot break out of
-            # the code fence and inject markdown into the trusted comment.
-            sanitized="$(sed 's/```/`\xE2\x80\x8b``/g' "$logf" | tail -n 300)"
+            content="$(tail -n 300 "$logf")"
+            # This log is fork-controlled. Prevent code-fence breakout by opening
+            # the block with MORE backticks than the longest backtick run in the
+            # content: a fence is only closed by an equal-or-longer run, so no
+            # line inside can terminate it. (Rewriting occurrences of ``` fails
+            # here - a longer run of backticks reconstructs a closing fence.)
+            maxrun="$(printf '%s' "$content" | { grep -oE '`+' || true; } | awk '{ if (length > m) m = length } END { print m + 0 }')"
+            fence_len=3
+            [ "${maxrun:-0}" -ge 3 ] && fence_len=$(( maxrun + 1 ))
+            fence="$(printf '`%.0s' $(seq "$fence_len"))"
             {
               printf '## %s - %s\n\n' "$title" "$status"
               if [ "$kind" = "report" ]; then
                 printf '_Informational only - shared runners are too noisy to gate on; full data is in the run artifacts._\n\n'
               fi
               printf '<details><summary>Output (last 300 lines)</summary>\n\n'
-              printf '```text\n'
-              printf '%s\n' "${sanitized:-(no output captured)}"
-              printf '```\n\n</details>\n\n'
+              printf '%stext\n' "$fence"
+              printf '%s\n' "${content:-(no output captured)}"
+              printf '%s\n\n</details>\n\n' "$fence"
             } >> body.md
             wrote=1
           done

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -3,8 +3,13 @@ name: PR Report Comment
 # comment on the PR. This is a SEPARATE workflow triggered via workflow_run so
 # it runs in the trusted base-repo context (with a write token) even when the
 # "Build" run it reports on came from an untrusted fork PR. It only consumes the
-# uploaded report artifact as DATA — it never checks out or executes the PR's
+# uploaded report artifact as DATA - it never checks out or executes the PR's
 # code, so a fork PR can never reach the token or repo secrets.
+#
+# The target PR number comes ONLY from trusted run metadata, never from the
+# artifact: a fork controls its own Build workflow (pull_request runs the fork's
+# copy of it), so an artifact-supplied PR number could be forged to redirect
+# this write-token comment onto an unrelated PR.
 #
 # NOTE: workflow_run only fires for the copy of this file on the default branch,
 # so it takes effect once merged to main (not from the PR that adds it).
@@ -24,7 +29,32 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve target PR from trusted metadata
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          # Populated for same-repo PRs; empty for fork PRs.
+          PR_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          set -euo pipefail
+          # SECURITY: take the target PR only from trusted run metadata, never
+          # from the downloaded artifact. A fork controls its own Build workflow
+          # and could forge a PR number to redirect this write-token comment. For
+          # forks the event's pull_requests[] is empty, so resolve it from the
+          # trusted head SHA instead.
+          pr="${PR_FROM_EVENT:-}"
+          if [ -z "$pr" ]; then
+            pr="$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
+                    --jq 'map(select(.state == "open")) | .[0].number // empty')"
+          fi
+          if [ -z "$pr" ]; then
+            echo "No open PR found for $HEAD_SHA; nothing to comment."
+          fi
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
       - name: Download report payloads from the triggering run
+        if: ${{ steps.pr.outputs.number != '' }}
         continue-on-error: true # a path-skipped Build uploads no payloads
         uses: actions/download-artifact@v4
         with:
@@ -33,9 +63,11 @@ jobs:
           pattern: pr-comment-*
           path: reports
       - name: Post combined comment
+        if: ${{ steps.pr.outputs.number != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -44,22 +76,13 @@ jobs:
             echo "No report payloads found; nothing to comment."
             exit 0
           fi
-          # Each payload carries the same PR number; take the first non-empty one.
-          pr=""
-          for nf in reports/pr-comment-*/pr-number.txt; do
-            pr="$(tr -dc '0-9' < "$nf")"
-            [ -n "$pr" ] && break
-          done
-          if [ -z "$pr" ]; then
-            echo "No PR number in payloads; nothing to comment."
-            exit 0
-          fi
           {
             for r in "${reports[@]}"; do
               cat "$r"
               printf '\n\n---\n\n'
             done
           } > body.md
-          # --body-file posts the content verbatim (no shell interpolation of the
-          # untrusted report text); the payload step already fenced/escaped it.
-          gh pr comment "$pr" --repo "$REPO" --body-file body.md
+          # --body-file posts content verbatim (no shell interpolation). The body
+          # is fork-influenced data but only ever lands on its own PR, and the
+          # payload step already fenced/escaped it.
+          gh pr comment "$PR" --repo "$REPO" --body-file body.md

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -2,14 +2,18 @@ name: PR Report Comment
 # Posts the valgrind / benchmark reports produced by the "Build" workflow as a
 # comment on the PR. This is a SEPARATE workflow triggered via workflow_run so
 # it runs in the trusted base-repo context (with a write token) even when the
-# "Build" run it reports on came from an untrusted fork PR. It only consumes the
-# uploaded report artifact as DATA - it never checks out or executes the PR's
-# code, so a fork PR can never reach the token or repo secrets.
+# "Build" run it reports on came from an untrusted fork PR.
 #
-# The target PR number comes ONLY from trusted run metadata, never from the
-# artifact: a fork controls its own Build workflow (pull_request runs the fork's
-# copy of it), so an artifact-supplied PR number could be forged to redirect
-# this write-token comment onto an unrelated PR.
+# Threat model: a fork controls its own Build workflow (pull_request runs the
+# fork's copy), so EVERYTHING the Build uploads is untrusted. This workflow
+# therefore:
+#   - resolves the target PR only from trusted workflow_run metadata (head repo
+#     + branch + SHA), never from artifact data;
+#   - consumes only the raw logs from the exact expected artifacts and does the
+#     fence-escaping, length cap, and markdown assembly HERE (a fork cannot make
+#     the Build skip escaping it does not perform);
+#   - takes pass/fail from the trusted jobs API, not from the artifact.
+# It never checks out or executes the PR's code.
 #
 # NOTE: workflow_run only fires for the copy of this file on the default branch,
 # so it takes effect once merged to main (not from the PR that adds it).
@@ -20,7 +24,7 @@ on:
 
 permissions:
   contents: read
-  actions: read # download artifacts from the triggering run
+  actions: read # download artifacts + read job conclusions from the run
   pull-requests: write # post the comment
 
 jobs:
@@ -35,54 +39,87 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          # Populated for same-repo PRs; empty for fork PRs.
-          PR_FROM_EVENT: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
-          # SECURITY: take the target PR only from trusted run metadata, never
-          # from the downloaded artifact. A fork controls its own Build workflow
-          # and could forge a PR number to redirect this write-token comment. For
-          # forks the event's pull_requests[] is empty, so resolve it from the
-          # trusted head SHA instead.
-          pr="${PR_FROM_EVENT:-}"
-          if [ -z "$pr" ]; then
-            pr="$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
-                    --jq 'map(select(.state == "open")) | .[0].number // empty')"
+          # Match the triggering PR by its trusted head owner:branch, then confirm
+          # the head SHA and require exactly one open match. This is reliable for
+          # forks (workflow_run.pull_requests[] is empty for them) and cannot be
+          # influenced by artifact contents.
+          mapfile -t hits < <(
+            gh api "repos/$REPO/pulls?state=open&head=$HEAD_OWNER:$HEAD_BRANCH&per_page=100" \
+              --jq '.[] | "\(.number) \(.head.sha)"' \
+              | awk -v s="$HEAD_SHA" '$2 == s { print $1 }'
+          )
+          if [ "${#hits[@]}" -eq 1 ]; then
+            echo "number=${hits[0]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Expected exactly one open PR for $HEAD_OWNER:$HEAD_BRANCH@$HEAD_SHA, found ${#hits[@]}; nothing to comment."
+            echo "number=" >> "$GITHUB_OUTPUT"
           fi
-          if [ -z "$pr" ]; then
-            echo "No open PR found for $HEAD_SHA; nothing to comment."
-          fi
-          echo "number=$pr" >> "$GITHUB_OUTPUT"
-      - name: Download report payloads from the triggering run
+      - name: Download report artifacts from the triggering run
         if: ${{ steps.pr.outputs.number != '' }}
-        continue-on-error: true # a path-skipped Build uploads no payloads
+        continue-on-error: true # a path-skipped Build uploads no artifacts
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: pr-comment-*
           path: reports
-      - name: Post combined comment
+      - name: Assemble and post comment
         if: ${{ steps.pr.outputs.number != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           PR: ${{ steps.pr.outputs.number }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          reports=(reports/pr-comment-*/report.md)
-          if [ ${#reports[@]} -eq 0 ]; then
-            echo "No report payloads found; nothing to comment."
+          # Only these artifacts are consumed; any other pr-comment-* artifact a
+          # fork may have uploaded is ignored. Each raw log is treated as
+          # UNTRUSTED and escaped/capped HERE. Fields: artifact|logfile|job name|kind
+          specs=(
+            "pr-comment-valgrind|valgrind.log|Valgrind Memory Checks|gated"
+            "pr-comment-benchmarks|bench.log|Benchmarks (report-only)|report"
+          )
+          jobs_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --jq '.jobs')"
+          : > body.md
+          wrote=0
+          for spec in "${specs[@]}"; do
+            IFS='|' read -r art logname title kind <<< "$spec"
+            logf="reports/$art/$logname"
+            [ -f "$logf" ] || continue
+            if [ "$kind" = "gated" ]; then
+              concl="$(printf '%s' "$jobs_json" | jq -r --arg n "$title" 'map(select(.name == $n)) | .[0].conclusion // "unknown"')"
+              case "$concl" in
+                success) status="PASSED" ;;
+                failure) status="FAILED" ;;
+                *) status="$concl" ;;
+              esac
+            else
+              status="report-only"
+            fi
+            # Neutralize any ``` in the untrusted log so it cannot break out of
+            # the code fence and inject markdown into the trusted comment.
+            sanitized="$(sed 's/```/`\xE2\x80\x8b``/g' "$logf" | tail -n 300)"
+            {
+              printf '## %s - %s\n\n' "$title" "$status"
+              if [ "$kind" = "report" ]; then
+                printf '_Informational only - shared runners are too noisy to gate on; full data is in the run artifacts._\n\n'
+              fi
+              printf '<details><summary>Output (last 300 lines)</summary>\n\n'
+              printf '```text\n'
+              printf '%s\n' "${sanitized:-(no output captured)}"
+              printf '```\n\n</details>\n\n'
+            } >> body.md
+            wrote=1
+          done
+          if [ "$wrote" -eq 0 ]; then
+            echo "No expected report artifacts present; nothing to comment."
             exit 0
           fi
-          {
-            for r in "${reports[@]}"; do
-              cat "$r"
-              printf '\n\n---\n\n'
-            done
-          } > body.md
-          # --body-file posts content verbatim (no shell interpolation). The body
-          # is fork-influenced data but only ever lands on its own PR, and the
-          # payload step already fenced/escaped it.
+          printf '_Commit `%s` - [full run](%s)_\n' "$HEAD_SHA" "$RUN_URL" >> body.md
           gh pr comment "$PR" --repo "$REPO" --body-file body.md

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -86,18 +86,37 @@ jobs:
             "pr-comment-benchmarks|bench.log|Benchmarks (report-only)|report"
           )
           jobs_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --jq '.jobs')"
+          # When the report jobs were path-skipped there are no artifacts. Only
+          # surface that explicitly for PRs that actually changed the CI/report
+          # workflows (the case where verifying the pipeline matters); staying
+          # quiet on unrelated PRs (docs, etc.) avoids comment noise.
+          touched_ci="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+            --jq '.[].filename' | grep -Ec '^\.github/workflows/' || true)"
           : > body.md
           wrote=0
           for spec in "${specs[@]}"; do
             IFS='|' read -r art logname title kind <<< "$spec"
             logf="reports/$art/$logname"
-            [ -f "$logf" ] || continue
+            concl="$(printf '%s' "$jobs_json" | jq -r --arg n "$title" 'map(select(.name == $n)) | .[0].conclusion // ""')"
+            if [ ! -f "$logf" ]; then
+              # No log: job was path-skipped or produced nothing. Note it only on
+              # workflow-touching PRs.
+              if [ "${touched_ci:-0}" -gt 0 ]; then
+                case "$concl" in
+                  skipped) note="Skipped - no relevant source changed in this PR." ;;
+                  "") note="Job not found in this run." ;;
+                  *) note="No report produced (job conclusion: $concl)." ;;
+                esac
+                printf '## %s - skipped\n\n_%s_\n\n' "$title" "$note" >> body.md
+                wrote=1
+              fi
+              continue
+            fi
             if [ "$kind" = "gated" ]; then
-              concl="$(printf '%s' "$jobs_json" | jq -r --arg n "$title" 'map(select(.name == $n)) | .[0].conclusion // "unknown"')"
               case "$concl" in
                 success) status="PASSED" ;;
                 failure) status="FAILED" ;;
-                *) status="$concl" ;;
+                *) status="${concl:-unknown}" ;;
               esac
             else
               status="report-only"
@@ -118,7 +137,7 @@ jobs:
             wrote=1
           done
           if [ "$wrote" -eq 0 ]; then
-            echo "No expected report artifacts present; nothing to comment."
+            echo "Nothing to report for this PR; not commenting."
             exit 0
           fi
           printf '_Commit `%s` - [full run](%s)_\n' "$HEAD_SHA" "$RUN_URL" >> body.md

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,65 @@
+name: PR Report Comment
+# Posts the valgrind / benchmark reports produced by the "Build" workflow as a
+# comment on the PR. This is a SEPARATE workflow triggered via workflow_run so
+# it runs in the trusted base-repo context (with a write token) even when the
+# "Build" run it reports on came from an untrusted fork PR. It only consumes the
+# uploaded report artifact as DATA — it never checks out or executes the PR's
+# code, so a fork PR can never reach the token or repo secrets.
+#
+# NOTE: workflow_run only fires for the copy of this file on the default branch,
+# so it takes effect once merged to main (not from the PR that adds it).
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # download artifacts from the triggering run
+  pull-requests: write # post the comment
+
+jobs:
+  comment:
+    # Only PR-triggered Build runs carry a PR to comment on (skip push to main).
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download report payloads from the triggering run
+        continue-on-error: true # a path-skipped Build uploads no payloads
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: pr-comment-*
+          path: reports
+      - name: Post combined comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          reports=(reports/pr-comment-*/report.md)
+          if [ ${#reports[@]} -eq 0 ]; then
+            echo "No report payloads found; nothing to comment."
+            exit 0
+          fi
+          # Each payload carries the same PR number; take the first non-empty one.
+          pr=""
+          for nf in reports/pr-comment-*/pr-number.txt; do
+            pr="$(tr -dc '0-9' < "$nf")"
+            [ -n "$pr" ] && break
+          done
+          if [ -z "$pr" ]; then
+            echo "No PR number in payloads; nothing to comment."
+            exit 0
+          fi
+          {
+            for r in "${reports[@]}"; do
+              cat "$r"
+              printf '\n\n---\n\n'
+            done
+          } > body.md
+          # --body-file posts the content verbatim (no shell interpolation of the
+          # untrusted report text); the payload step already fenced/escaped it.
+          gh pr comment "$pr" --repo "$REPO" --body-file body.md


### PR DESCRIPTION
## What

Surface the **valgrind** and **benchmark** job results as a comment on each PR — including PRs from forks — so they can be eyeballed before reviewing the diff.

## How

- The `valgrind` and `benchmark` jobs in the `Build` workflow now tee their output, render a markdown report + the PR number, and upload them as a `pr-comment-*` artifact (only on PRs; `if: always()` so a failing valgrind run still reports).
- A new `pr-comment.yml` runs via `workflow_run`, so it executes in the **trusted base-repo context** (write token) even when the `Build` run came from a fork PR. It only consumes the report artifact as **data** — it never checks out or runs PR code — so fork PRs cannot reach the token or repo secrets. Report output is fenced and ```-escaped to prevent markdown injection from a hostile PR.

## Notes

- `workflow_run` only fires from the copy of `pr-comment.yml` on the default branch, so the first comment appears on the **next** PR after this merges (not on this PR).
- If comments don't appear post-merge, check **Settings → Actions → General → Workflow permissions** allows `GITHUB_TOKEN` pull-request write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)