### PR TITLE
release: prepare mux-compiler 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,27 +5,70 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-07-13
+
+This release completes the split of the former monorepo into independent repos.
+`mux-compiler` is now the canonical "Mux version" and resolves/reports the runtime
+version independently; the runtime, website, playground API, and syntax
+highlighting each live in and version from their own repos. Requires
+`mux-runtime` 0.5.0.
 
 ### Added
+- **Where-clause constraints**: `where { expr, ... }` attaches runtime constraints to
+  functions, methods, lambdas, interface methods, enum variants, fields, and classes.
+  Provable violations are compile errors (zero-false-positive); the runtime panic is the
+  fallback. Closes #224 (#235).
+- **Reject provable runtime panics at compile time**: The compiler now turns provable
+  runtime panics into compile-time errors, using the zero-false-positive const-fold path.
+  Closes #238.
 - **`cargo bench` harness (criterion)**: Compiler-phase benchmarks (`lex`, `parse`, `semantics`,
   `codegen`, end-to-end `pipeline`) run over the whole compiling `test_scripts` corpus, plus
   end-to-end `execution` throughput benchmarks for a curated set of compiled workloads. A
   stdlib-only `scripts/bench-report.py` aggregates the per-file medians into a box-and-whisker
   per phase. Benchmarks are local/manual and a non-blocking CI report, never a merge gate.
   Closes #247.
+- **Valgrind memory checking**: CI now runs compiled programs and the compiler under Valgrind
+  (Memcheck), gating on definite/indirect leaks and memory errors with checked-in suppressions
+  for benign third-party noise. Closes #246.
+- **Range-literal syntax diagnostic**: A targeted diagnostic for a digit followed by `..`
+  (range-literal syntax) replaces the previous generic parse error. Closes #245.
+- **Independent runtime version resolution**: The compiler resolves and reports the runtime
+  version independently of its own version, so `mux --version` reports both (e.g.
+  `mux 0.5.0 (runtime 0.5.0)`).
 
 ### Changed
+- **Repo split from the monorepo**: Extracted the runtime, website, playground API, and syntax
+  highlighting into their own repos; removed the root `VERSION` file and `sync-version` tooling;
+  scoped the SonarCloud analysis to the compiler; and rebound the project identity to
+  `muxlang/mux-compiler`. Internals documentation now points at `muxlang/mux-context`.
+- **CLI polish**: Colored diagnostics, styled help output, doctor glyphs, a version banner, and
+  a compile spinner. Closes #249.
+- **Runtime panic documentation and behavior updated** (#225, #230).
 - **Removed ad-hoc perf tooling**: Deleted `scripts/measure-baseline.sh`,
   `scripts/check-timings.py`, and the orphaned `infra/ci/baselines/*.json` timing budgets, and
   stripped the unused `--timings-file` plumbing from `run-checks.sh` / `integration-checks.sh`.
   Also removed the unused `cargo-fuzz` setup under `mux-compiler/fuzz/`.
+- **Slimmed the README** to a real README and pointed internals at `muxlang/mux-context`.
 
 ### Fixed
 - **`mux build` / `mux run` now fail on link errors**: A failed `clang` link previously printed
   the error but exited 0 (`build` reported success with no executable; `run` could fall through
   and execute a stale binary from a prior build). `report_clang_output_or_exit` now exits
   non-zero as its name implies.
+- **Reference-counting correctness**: Reference-count cleanup for owned temporaries plus
+  init/copy correctness fixes (#253); closures are now allocated with a reference-count header.
+  Closes #250 (#252).
+- **Collection read-path performance and correctness**: Fixed O(n^2) indexed reads,
+  runtime-cache staleness, and Python-style negative indexing on collection reads
+  (#256, #258, #259, #260).
+- **`match` usable as a statement**: `match` now works as a statement and the guarded-arm
+  exhaustiveness hole is closed (#233, #234, #243) (#242).
+- **Trailing commas**: Allow trailing commas before newline-closed collection delimiters (#244).
+- **Enum codegen**: Load enums from boxed pointers correctly in codegen (#237).
+- **Release checksum verification**: Verify release checksums by hash, not path.
+
+### Security
+- **`cmov` 0.5.3 -> 0.5.4**: Bumped to fix GHSA-3rjw-m598-pq24 (#254).
 
 ## [0.4.1] - 2026-06-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "mux-lang"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,9 +1213,9 @@ dependencies = [
 
 [[package]]
 name = "mux-runtime"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912de1485e843aed82dc94305a92f8e962e6ff513ef6d9fefa2e1128a9a45d59"
+checksum = "b3450164d8603a7f2f7feeabb66de8a6719514a38bb67daefb77ba5f4f44f330"
 dependencies = [
  "chrono",
  "csv",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The Programming Language For Everyone**
 
-[![Version](https://img.shields.io/badge/version-0.4.1-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
+[![Version](https://img.shields.io/badge/version-0.5.0-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 [![crates.io](https://img.shields.io/crates/v/mux-lang.svg?style=flat-square)](https://crates.io/crates/mux-lang)
 [![Documentation](https://img.shields.io/badge/docs-online-blue.svg?style=flat-square)](https://mux-lang.dev)
@@ -195,7 +195,7 @@ Profiling is done with external tools so it stays decoupled from the compiler an
 
 ⚠️ **Alpha Stage**: Mux is actively being developed. Expect breaking changes and incomplete features as we work toward a stable release.
 
-- **Current Version:** 0.4.1
+- **Current Version:** 0.5.0
 
 ## Versioning
 

--- a/mux-compiler/Cargo.toml
+++ b/mux-compiler/Cargo.toml
@@ -32,7 +32,7 @@ unicode-width = "0.1.11"
 lazy_static = "1.4"
 inkwell = { version = "0.9.0", features = ["llvm22-1"] }
 clap = { version = "4", features = ["derive"] }
-mux-runtime = "0.4.1"
+mux-runtime = "0.5"
 phf = { version = "0.11", features = ["macros"] }
 
 [dev-dependencies]

--- a/mux-compiler/Cargo.toml
+++ b/mux-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mux-lang"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 default-run = "mux"
 description = "The Mux Programming Language Compiler"


### PR DESCRIPTION
Prepares the compiler (the canonical "Mux version") for the coordinated **v0.5.0** ecosystem release, which completes the monorepo -> multi-repo split.

## Changes
- Bump `mux-lang` `version` 0.4.1 -> 0.5.0 (`mux-compiler/Cargo.toml`); refresh `Cargo.lock`.
- Fold `CHANGELOG.md` `[Unreleased]` into `[0.5.0]`, covering all 36 commits since v0.4.1 (where-clause constraints #235, compile-time panic rejection #238, CLI polish #249, Valgrind gate #246, refcount/closure fixes #252/#253, collection read-path fixes #256/#258/#259/#260, `match`-as-statement #242, cmov security bump #254, the repo split, and more).
- Update README version badge + `Current Version` line.
- Add a breakpoint note in the shared changelog history is not needed here: this repo IS the source of the pre-split history.

## Deferred to maintainer (release-process.md step 6)
The `mux-runtime = "0.4.1"` -> `"0.5"` dependency bump and its `Cargo.lock` refresh are **intentionally not in this PR**. The compiler cannot resolve/build `--locked` against `mux-runtime 0.5.0` until it is published to crates.io, so bumping now would leave `main` red. After the runtime is published:
1. `mux-runtime 0.5.0` -> crates.io (see mux-runtime#19).
2. Here: set `mux-runtime = "0.5"`, `cargo update -p mux-runtime`, `cargo build` (lock -> 0.5.0, `MUX_RUNTIME_VERSION` -> 0.5.0, `mux version` reports `runtime 0.5.0`).
3. `git tag -a v0.5.0`, `cargo publish`, cut the GitHub Release with binaries.

## Verification
Full `cargo test` (incl. executable-integration) passed locally with `MUX_RUNTIME_SRC` pointed at the 0.5.0 runtime source, so the compiler 0.5.0 + runtime 0.5.0 coupling (new FFI symbols) is exercised. `mux version` reports `compiler v0.5.0`.