### PR TITLE
ci: render valgrind and benchmark PR reports as charts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,6 @@ jobs:
             bench.log
             bench-summary.json
           if-no-files-found: warn
-          if-no-files-found: warn
   sonarqube:
     name: SonarQube
     # Runs on every push and pull request (no path gating): SonarQube analyzes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
           set -o pipefail
           cargo bench -p mux-lang 2>&1 | tee bench.log
       - name: Build per-phase distribution report
-        run: python3 scripts/bench-report.py
+        run: python3 scripts/bench-report.py --summary-json bench-summary.json
       - name: Upload benchmark report
         uses: actions/upload-artifact@v4
         with:
@@ -268,12 +268,17 @@ jobs:
             target/criterion/
           if-no-files-found: warn
       - name: Upload benchmark log for PR comment
-        # Raw log only; the trusted pr-comment workflow escapes and renders it.
+        # Raw log (escaped/rendered by the trusted pr-comment workflow) plus the
+        # compact per-phase summary it turns into charts. Both are fork-controlled
+        # and re-validated there; nothing here is trusted.
         if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/upload-artifact@v4
         with:
           name: pr-comment-benchmarks
-          path: bench.log
+          path: |
+            bench.log
+            bench-summary.json
+          if-no-files-found: warn
           if-no-files-found: warn
   sonarqube:
     name: SonarQube

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -92,6 +92,99 @@ jobs:
           # quiet on unrelated PRs (docs, etc.) avoids comment noise.
           touched_ci="$(gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
             --jq '.[].filename' | grep -Ec '^\.github/workflows/' || true)"
+
+          # INJECTION MODEL: charts/tables below must contain ONLY data this step
+          # can prove safe - integers/floats we numeric-validate, and phase labels
+          # from the fixed whitelist BELOW (never a string read from an artifact).
+          # A fork-controlled name/median that fails validation is dropped, not
+          # echoed. The one place raw fork text appears is the escaped <details>.
+
+          # Render the fork-controlled raw log inside a code fence it cannot break
+          # out of: open with MORE backticks than the longest backtick run inside
+          # (a fence only closes on an equal-or-longer run).
+          emit_raw_details() {
+            local logf="$1" summary="$2" content maxrun fence_len fence
+            content="$(tail -n 300 "$logf")"
+            maxrun="$(printf '%s' "$content" | { grep -oE '`+' || true; } | awk '{ if (length > m) m = length } END { print m + 0 }')"
+            fence_len=3
+            [ "${maxrun:-0}" -ge 3 ] && fence_len=$(( maxrun + 1 ))
+            fence="$(printf '`%.0s' $(seq "$fence_len"))"
+            printf '<details><summary>%s</summary>\n\n' "$summary"
+            printf '%stext\n' "$fence"
+            printf '%s\n' "${content:-(no output captured)}"
+            printf '%s\n\n</details>\n\n' "$fence"
+          }
+
+          is_num() { [[ "$1" =~ ^[0-9]+(\.[0-9]+)?$ ]]; }
+
+          human_ns() {
+            awk -v ns="$1" 'BEGIN {
+              if (ns >= 1e9) printf "%.3g s", ns/1e9;
+              else if (ns >= 1e6) printf "%.3g ms", ns/1e6;
+              else if (ns >= 1e3) printf "%.3g us", ns/1e3;
+              else printf "%.3g ns", ns;
+            }'
+          }
+
+          # One xychart-beta bar per magnitude group so orders-of-magnitude phases
+          # do not flatten (mermaid xychart has no log axis). $1 unit label, $2 ns
+          # divisor, $3 chart title, remaining args: whitelisted phase names.
+          emit_bench_group() {
+            local unit="$1" divisor="$2" title="$3"; shift 3
+            local name med val labels="" values="" any=0
+            for name in "$@"; do
+              med="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .median_ns) // empty' "$SUMMARY" 2>/dev/null || true)"
+              is_num "$med" || continue
+              val="$(awk -v m="$med" -v d="$divisor" 'BEGIN { printf "%.4g", m / d }')"
+              labels="${labels:+$labels, }\"$name\""
+              values="${values:+$values, }$val"
+              any=1
+            done
+            [ "$any" -eq 1 ] || return 0
+            printf '```mermaid\n'
+            printf 'xychart-beta\n'
+            printf '    title "%s"\n' "$title"
+            printf '    x-axis [%s]\n' "$labels"
+            printf '    y-axis "%s"\n' "$unit"
+            printf '    bar [%s]\n' "$values"
+            printf '```\n\n'
+          }
+
+          emit_bench_report() {
+            # SUMMARY is a fork-produced JSON; jq reads it but every value is
+            # numeric-validated and every label is a trusted literal below.
+            [ -f "$SUMMARY" ] || return 0
+            emit_bench_group "microseconds" 1000 "Compile phases (median)" lex parse semantics codegen
+            emit_bench_group "milliseconds" 1000000 "Pipeline + execution (median)" pipeline execution
+            local name med n rows=""
+            for name in lex parse semantics codegen pipeline execution; do
+              med="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .median_ns) // empty' "$SUMMARY" 2>/dev/null || true)"
+              is_num "$med" || continue
+              n="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .n) // empty' "$SUMMARY" 2>/dev/null || true)"
+              [[ "$n" =~ ^[0-9]+$ ]] || n="?"
+              rows="${rows}| \`$name\` | $(human_ns "$med") | $n |"$'\n'
+            done
+            [ -n "$rows" ] || return 0
+            printf '| Phase | Median | Samples |\n|:--|--:|--:|\n%s\n' "$rows"
+          }
+
+          # Leg A prints "N program(s), M failure(s)"; take those two integers only.
+          emit_valgrind_pie() {
+            local logf="$1" line total fails clean
+            line="$(grep -Eo '[0-9]+ program\(s\), [0-9]+ failure\(s\)' "$logf" | tail -n 1 || true)"
+            [ -n "$line" ] || return 0
+            total="$(printf '%s' "$line" | grep -Eo '^[0-9]+' || true)"
+            fails="$(printf '%s' "$line" | grep -Eo '[0-9]+ failure' | grep -Eo '^[0-9]+' || true)"
+            { [[ "$total" =~ ^[0-9]+$ ]] && [[ "$fails" =~ ^[0-9]+$ ]] && [ "$total" -gt 0 ] && [ "$fails" -le "$total" ]; } || return 0
+            clean=$(( total - fails ))
+            printf '```mermaid\n'
+            printf 'pie showData\n'
+            printf '    title Leg A: compiled programs under Valgrind (%s total)\n' "$total"
+            printf '    "Clean" : %s\n' "$clean"
+            printf '    "Leaking" : %s\n' "$fails"
+            printf '```\n\n'
+          }
+
           : > body.md
           wrote=0
           for spec in "${specs[@]}"; do
@@ -121,25 +214,19 @@ jobs:
             else
               status="report-only"
             fi
-            content="$(tail -n 300 "$logf")"
-            # This log is fork-controlled. Prevent code-fence breakout by opening
-            # the block with MORE backticks than the longest backtick run in the
-            # content: a fence is only closed by an equal-or-longer run, so no
-            # line inside can terminate it. (Rewriting occurrences of ``` fails
-            # here - a longer run of backticks reconstructs a closing fence.)
-            maxrun="$(printf '%s' "$content" | { grep -oE '`+' || true; } | awk '{ if (length > m) m = length } END { print m + 0 }')"
-            fence_len=3
-            [ "${maxrun:-0}" -ge 3 ] && fence_len=$(( maxrun + 1 ))
-            fence="$(printf '`%.0s' $(seq "$fence_len"))"
             {
               printf '## %s - %s\n\n' "$title" "$status"
-              if [ "$kind" = "report" ]; then
+              if [ "$art" = "pr-comment-valgrind" ]; then
+                emit_valgrind_pie "$logf"
+                emit_raw_details "$logf" "Full valgrind output (last 300 lines)"
+              elif [ "$art" = "pr-comment-benchmarks" ]; then
                 printf '_Informational only - shared runners are too noisy to gate on; full data is in the run artifacts._\n\n'
+                SUMMARY="reports/$art/bench-summary.json"
+                emit_bench_report
+                emit_raw_details "$logf" "Full benchmark output (last 300 lines)"
+              else
+                emit_raw_details "$logf" "Output (last 300 lines)"
               fi
-              printf '<details><summary>Output (last 300 lines)</summary>\n\n'
-              printf '%stext\n' "$fence"
-              printf '%s\n' "${content:-(no output captured)}"
-              printf '%s\n\n</details>\n\n' "$fence"
             } >> body.md
             wrote=1
           done

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -126,14 +126,23 @@ jobs:
             }'
           }
 
+          # Whitelisted compile phases, split by magnitude. These labels are the
+          # ONLY phase strings that can reach the comment body, so this list is a
+          # security control, not just ordering. Keep it in sync with
+          # PREFERRED_ORDER in scripts/bench-report.py: a phase added there but
+          # not here is silently left out of the charts (by design - unknown
+          # names are dropped rather than rendered).
+          BENCH_FAST_PHASES="lex parse semantics codegen"
+          BENCH_SLOW_PHASES="pipeline execution"
+
           # One xychart-beta bar per magnitude group so orders-of-magnitude phases
-          # do not flatten (mermaid xychart has no log axis). $1 unit label, $2 ns
-          # divisor, $3 chart title, remaining args: whitelisted phase names.
+          # do not flatten (mermaid xychart has no log axis). $1 summary json,
+          # $2 unit label, $3 ns divisor, $4 chart title, rest: phase names.
           emit_bench_group() {
-            local unit="$1" divisor="$2" title="$3"; shift 3
+            local summary="$1" unit="$2" divisor="$3" title="$4"; shift 4
             local name med val labels="" values="" any=0
             for name in "$@"; do
-              med="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .median_ns) // empty' "$SUMMARY" 2>/dev/null || true)"
+              med="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .median_ns) // empty' "$summary" 2>/dev/null || true)"
               is_num "$med" || continue
               val="$(awk -v m="$med" -v d="$divisor" 'BEGIN { printf "%.4g", m / d }')"
               labels="${labels:+$labels, }\"$name\""
@@ -150,17 +159,23 @@ jobs:
             printf '```\n\n'
           }
 
+          # $1: path to the fork-produced summary json. jq reads it, but every
+          # value is numeric-validated and every label is a trusted literal above.
           emit_bench_report() {
-            # SUMMARY is a fork-produced JSON; jq reads it but every value is
-            # numeric-validated and every label is a trusted literal below.
-            [ -f "$SUMMARY" ] || return 0
-            emit_bench_group "microseconds" 1000 "Compile phases (median)" lex parse semantics codegen
-            emit_bench_group "milliseconds" 1000000 "Pipeline + execution (median)" pipeline execution
+            local summary="$1"
+            if [ -z "$summary" ] || [ ! -f "$summary" ]; then
+              echo "note: no bench summary at '${summary:-<unset>}'; skipping charts" >&2
+              return 0
+            fi
+            # shellcheck disable=SC2086 # word splitting is the intent
+            emit_bench_group "$summary" "microseconds" 1000 "Compile phases (median)" $BENCH_FAST_PHASES
+            # shellcheck disable=SC2086
+            emit_bench_group "$summary" "milliseconds" 1000000 "Pipeline + execution (median)" $BENCH_SLOW_PHASES
             local name med n rows=""
-            for name in lex parse semantics codegen pipeline execution; do
-              med="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .median_ns) // empty' "$SUMMARY" 2>/dev/null || true)"
+            for name in $BENCH_FAST_PHASES $BENCH_SLOW_PHASES; do
+              med="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .median_ns) // empty' "$summary" 2>/dev/null || true)"
               is_num "$med" || continue
-              n="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .n) // empty' "$SUMMARY" 2>/dev/null || true)"
+              n="$(jq -r --arg p "$name" '(.phases[] | select(.name == $p) | .n) // empty' "$summary" 2>/dev/null || true)"
               [[ "$n" =~ ^[0-9]+$ ]] || n="?"
               rows="${rows}| \`$name\` | $(human_ns "$med") | $n |"$'\n'
             done
@@ -221,8 +236,7 @@ jobs:
                 emit_raw_details "$logf" "Full valgrind output (last 300 lines)"
               elif [ "$art" = "pr-comment-benchmarks" ]; then
                 printf '_Informational only - shared runners are too noisy to gate on; full data is in the run artifacts._\n\n'
-                SUMMARY="reports/$art/bench-summary.json"
-                emit_bench_report
+                emit_bench_report "reports/$art/bench-summary.json"
                 emit_raw_details "$logf" "Full benchmark output (last 300 lines)"
               else
                 emit_raw_details "$logf" "Output (last 300 lines)"

--- a/scripts/bench-report.py
+++ b/scripts/bench-report.py
@@ -204,6 +204,12 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("criterion_dir", nargs="?", type=Path)
     parser.add_argument("-o", "--output", type=Path)
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        help="also write a compact {phases:[{name,median_ns,n}]} JSON here "
+        "(consumed by the PR-comment workflow to render charts).",
+    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parent.parent
@@ -243,6 +249,18 @@ def main() -> int:
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(HTML.format(svg=svg), encoding="utf-8")
     print(f"wrote {output}")
+
+    if args.summary_json is not None:
+        summary_json = confined(args.summary_json, "summary json")
+        summary_json.parent.mkdir(parents=True, exist_ok=True)
+        summary = {
+            "phases": [
+                {"name": name, "median_ns": stats[name]["q2"], "n": counts[name]}
+                for name in order
+            ]
+        }
+        summary_json.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        print(f"wrote {summary_json}")
     for name in order:
         s = stats[name]
         print(

--- a/scripts/bench-report.py
+++ b/scripts/bench-report.py
@@ -23,6 +23,12 @@ from pathlib import Path
 
 # Phase groups in pipeline order; any other group found (e.g. execution) is
 # appended after these.
+#
+# `--summary-json` feeds the PR-comment workflow, which has its own whitelist of
+# phase labels (BENCH_FAST_PHASES / BENCH_SLOW_PHASES in
+# .github/workflows/pr-comment.yml) and drops anything not on it. A phase added
+# here shows up in the JSON and this script's own report, but stays out of the PR
+# charts until it is added there too.
 PREFERRED_ORDER = ["lex", "parse", "semantics", "codegen", "pipeline", "execution"]
 
 
@@ -261,6 +267,7 @@ def main() -> int:
         }
         summary_json.write_text(json.dumps(summary, indent=2), encoding="utf-8")
         print(f"wrote {summary_json}")
+
     for name in order:
         s = stats[name]
         print(


### PR DESCRIPTION
Part of muxlang/mux-context#15.

## Why

The PR comment dumped the last 300 lines of each raw log, which is hard to read at a glance.

## What

Render the report instead, all in the one comment:

- a pie of the Leg A clean/leaking split,
- per-phase median bars,
- an exact-numbers table,
- raw logs kept in the existing collapsed `<details>`.

Phases span orders of magnitude and mermaid's `xychart` has **no log axis**, so the fast phases and `pipeline`/`execution` are charted separately rather than flattening `lex`/`parse` to nothing. The table stays the exact source.

`bench-report.py` grows `--summary-json`, emitting a compact `{phases:[{name,median_ns,n}]}` summary uploaded next to `bench.log`.

## Security

Everything the Build uploads is fork-controlled (a fork runs its own copy of the Build workflow), so the rendered body contains only data this workflow can prove safe:

- phase labels come from a **fixed whitelist here**, never a string read from the artifact;
- every median and count is numeric-validated, and anything failing validation is **dropped, not echoed**;
- raw log text keeps the existing fence-escaping.

Verified locally against hostile inputs: an injected phase name, a non-numeric median containing markdown/mermaid breakout characters, and `failures > total` are all dropped.

## Note

`workflow_run` only fires for the copy of `pr-comment.yml` on the default branch, so this takes effect once merged, not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)