### PR TITLE
Release enum heap payloads at teardown

### DIFF
--- a/mux-compiler/src/codegen/functions.rs
+++ b/mux-compiler/src/codegen/functions.rs
@@ -396,33 +396,20 @@ impl<'a> CodeGenerator<'a> {
     /// rather than lost, because the global slot still points at them, so the
     /// leak legs of CI stay green while the memory is never freed.
     fn emit_global_teardown(&mut self) -> Result<(), String> {
-        let rc_dec = self
-            .runtime_function("mux_rc_dec")
-            .ok_or("mux_rc_dec not found")?;
-        let ptr_type = self.context.ptr_type(AddressSpace::default());
-
         let mut owned_globals = self.collect_teardown_slots();
         owned_globals.sort_by(|a, b| a.0.cmp(&b.0));
         let mut released = std::collections::HashSet::new();
-        owned_globals.retain(|(_, alloca)| released.insert(*alloca));
-
-        for (name, alloca) in owned_globals {
-            let value = self
-                .builder
-                .build_load(ptr_type, alloca, &format!("global_teardown_load_{}", name))
-                .map_err(|e| e.to_string())?;
-            self.builder
-                .build_call(rc_dec, &[value.into()], &format!("global_dec_{}", name))
-                .map_err(|e| e.to_string())?;
-        }
-        Ok(())
+        owned_globals.retain(|(_, slot)| released.insert(slot.alloca()));
+        // Reuse the local-scope cleanup dispatch: boxed globals are decremented
+        // directly and inline enum-struct globals get variant-tag drop-glue.
+        self.generate_cleanup_for_vars(&owned_globals)
     }
 
     /// Every RC-owned global slot that program exit is responsible for
     /// releasing, gathered from the main-module view and every module table.
     /// Names are qualified by module so the emitted IR labels stay unique;
     /// callers dedupe by slot, since one slot can appear under several names.
-    fn collect_teardown_slots(&self) -> Vec<(String, inkwell::values::PointerValue<'a>)> {
+    fn collect_teardown_slots(&self) -> Vec<(String, super::RcSlot<'a>)> {
         let main_table = std::iter::once((None, &self.global_variables));
         let module_tables = self
             .module_globals
@@ -435,23 +422,39 @@ impl<'a> CodeGenerator<'a> {
                 table
                     .iter()
                     .filter_map(move |(name, (alloca, llvm_type, ty))| {
-                        // Only globals whose storage is a boxed RC pointer can be
-                        // decremented. Value-semantic types stored inline (e.g.
-                        // custom enums held as a struct) are not RC pointers -
-                        // loading and decrementing them would dereference a
-                        // non-pointer. References and functions borrow their target
-                        // and are managed elsewhere.
+                        let label = match module {
+                            Some(module) => format!("{}_{}", module, name),
+                            None => name.clone(),
+                        };
+                        // Inline custom-enum globals are value-semantic structs,
+                        // not boxed RC pointers, so they need variant-tag drop-glue
+                        // to release their active variant's pointer payloads. Only
+                        // enums that actually own a pointer payload are worth a
+                        // slot.
+                        if let Some(enum_name) = self.user_enum_type_name(ty) {
+                            if self.enum_has_rc_payload(&enum_name) {
+                                return Some((
+                                    label,
+                                    super::RcSlot::EnumStruct {
+                                        enum_name,
+                                        alloca: *alloca,
+                                    },
+                                ));
+                            }
+                            return None;
+                        }
+                        // Otherwise only globals whose storage is a boxed RC
+                        // pointer can be decremented; loading and decrementing an
+                        // inline non-pointer would dereference a non-pointer.
+                        // References and functions borrow their target and are
+                        // managed elsewhere.
                         if !llvm_type.is_pointer_type()
                             || !self.type_needs_rc_tracking(ty)
                             || matches!(ty, Type::Reference(_) | Type::Function { .. })
                         {
                             return None;
                         }
-                        let label = match module {
-                            Some(module) => format!("{}_{}", module, name),
-                            None => name.clone(),
-                        };
-                        Some((label, *alloca))
+                        Some((label, super::RcSlot::Boxed(*alloca)))
                     })
             })
             .collect()

--- a/mux-compiler/src/codegen/memory.rs
+++ b/mux-compiler/src/codegen/memory.rs
@@ -5,6 +5,7 @@
 use super::{CodeGenerator, RcSlot};
 use crate::semantics::Type;
 use inkwell::AddressSpace;
+use inkwell::types::BasicTypeEnum;
 use inkwell::values::{BasicValueEnum, PointerValue};
 
 impl<'a> CodeGenerator<'a> {
@@ -79,20 +80,25 @@ impl<'a> CodeGenerator<'a> {
         Ok(())
     }
 
-    /// Track an RC-allocated variable in the current scope.
-    /// The variable will have mux_rc_dec called on it when the scope ends.
-    pub(super) fn track_rc_variable(&mut self, name: &str, alloca: PointerValue<'a>) {
+    /// Add a cleanup slot to the current scope, skipping it if the same storage
+    /// slot is already tracked there - a duplicate would be decremented twice at
+    /// cleanup. Shared by the boxed and enum tracking entry points.
+    fn track_slot(&mut self, name: &str, slot: RcSlot<'a>) {
         if let Some(current_scope) = self.rc_scope_stack.last_mut() {
-            // Avoid duplicate tracking of the same storage slot inside a scope.
-            // Duplicates can lead to double decrements during cleanup.
             if current_scope
                 .iter()
-                .any(|(_, slot)| slot.alloca() == alloca)
+                .any(|(_, s)| s.alloca() == slot.alloca())
             {
                 return;
             }
-            current_scope.push((name.to_string(), RcSlot::Boxed(alloca)));
+            current_scope.push((name.to_string(), slot));
         }
+    }
+
+    /// Track an RC-allocated variable in the current scope.
+    /// The variable will have mux_rc_dec called on it when the scope ends.
+    pub(super) fn track_rc_variable(&mut self, name: &str, alloca: PointerValue<'a>) {
+        self.track_slot(name, RcSlot::Boxed(alloca));
     }
 
     /// Track an inline enum-struct local so its active variant's pointer payloads
@@ -105,21 +111,13 @@ impl<'a> CodeGenerator<'a> {
         enum_name: &str,
         alloca: PointerValue<'a>,
     ) {
-        if let Some(current_scope) = self.rc_scope_stack.last_mut() {
-            if current_scope
-                .iter()
-                .any(|(_, slot)| slot.alloca() == alloca)
-            {
-                return;
-            }
-            current_scope.push((
-                name.to_string(),
-                RcSlot::EnumStruct {
-                    enum_name: enum_name.to_string(),
-                    alloca,
-                },
-            ));
-        }
+        self.track_slot(
+            name,
+            RcSlot::EnumStruct {
+                enum_name: enum_name.to_string(),
+                alloca,
+            },
+        );
     }
 
     /// If `ty` is a user-declared enum (not the built-in `optional`/`result`,
@@ -173,11 +171,19 @@ impl<'a> CodeGenerator<'a> {
             return Ok(());
         }
 
-        let struct_type = self
-            .type_map
-            .get(enum_name)
-            .ok_or_else(|| format!("Enum {} not found in type map", enum_name))?
-            .into_struct_type();
+        // generate_enum_type always stores a StructType here; match rather than
+        // `into_struct_type()` so a violated invariant surfaces as a diagnostic
+        // instead of panicking the compiler.
+        let struct_type = match self.type_map.get(enum_name) {
+            Some(BasicTypeEnum::StructType(struct_type)) => *struct_type,
+            Some(_) => {
+                return Err(format!(
+                    "Enum {} type map entry is not a struct type",
+                    enum_name
+                ));
+            }
+            None => return Err(format!("Enum {} not found in type map", enum_name)),
+        };
         let rc_dec = self
             .runtime_function("mux_rc_dec")
             .ok_or("mux_rc_dec not found")?;

--- a/mux-compiler/src/codegen/memory.rs
+++ b/mux-compiler/src/codegen/memory.rs
@@ -2,7 +2,7 @@
 //!
 //! This module handles tracking RC-allocated variables and generating cleanup code.
 
-use super::CodeGenerator;
+use super::{CodeGenerator, RcSlot};
 use crate::semantics::Type;
 use inkwell::AddressSpace;
 use inkwell::values::{BasicValueEnum, PointerValue};
@@ -29,7 +29,7 @@ impl<'a> CodeGenerator<'a> {
         self.cleanup_all_closure_temps()?;
 
         // Collect all variables from all scopes to avoid borrow issues
-        let all_vars: Vec<(String, PointerValue<'a>)> = self
+        let all_vars: Vec<(String, RcSlot<'a>)> = self
             .rc_scope_stack
             .iter()
             .rev()
@@ -47,27 +47,34 @@ impl<'a> CodeGenerator<'a> {
         self.generate_closure_cleanup_for_vars(&all_closures)
     }
 
-    /// Generate mux_rc_dec calls for a list of variables.
+    /// Release a list of tracked scope slots. Boxed `*mut Value` slots are
+    /// decremented directly; inline enum-struct slots are released with
+    /// `emit_enum_drop`, which decrements only the pointer payloads of the
+    /// value's active variant.
     pub(super) fn generate_cleanup_for_vars(
         &mut self,
-        vars: &[(String, PointerValue<'a>)],
+        vars: &[(String, RcSlot<'a>)],
     ) -> Result<(), String> {
         let rc_dec = self
             .runtime_function("mux_rc_dec")
             .ok_or("mux_rc_dec not found")?;
         let ptr_type = self.context.ptr_type(AddressSpace::default());
 
-        for (name, alloca) in vars {
-            // Load the pointer value from the alloca
-            let value = self
-                .builder
-                .build_load(ptr_type, *alloca, &format!("rc_load_{}", name))
-                .map_err(|e| e.to_string())?;
-
-            // Call mux_rc_dec
-            self.builder
-                .build_call(rc_dec, &[value.into()], &format!("rc_dec_{}", name))
-                .map_err(|e| e.to_string())?;
+        for (name, slot) in vars {
+            match slot {
+                RcSlot::Boxed(alloca) => {
+                    let value = self
+                        .builder
+                        .build_load(ptr_type, *alloca, &format!("rc_load_{}", name))
+                        .map_err(|e| e.to_string())?;
+                    self.builder
+                        .build_call(rc_dec, &[value.into()], &format!("rc_dec_{}", name))
+                        .map_err(|e| e.to_string())?;
+                }
+                RcSlot::EnumStruct { enum_name, alloca } => {
+                    self.emit_enum_drop(enum_name, *alloca)?;
+                }
+            }
         }
         Ok(())
     }
@@ -78,11 +85,183 @@ impl<'a> CodeGenerator<'a> {
         if let Some(current_scope) = self.rc_scope_stack.last_mut() {
             // Avoid duplicate tracking of the same storage slot inside a scope.
             // Duplicates can lead to double decrements during cleanup.
-            if current_scope.iter().any(|(_, p)| *p == alloca) {
+            if current_scope
+                .iter()
+                .any(|(_, slot)| slot.alloca() == alloca)
+            {
                 return;
             }
-            current_scope.push((name.to_string(), alloca));
+            current_scope.push((name.to_string(), RcSlot::Boxed(alloca)));
         }
+    }
+
+    /// Track an inline enum-struct local so its active variant's pointer payloads
+    /// are released when the scope ends. Enums are value-semantic structs, not
+    /// boxed `*mut Value`s, so they need `emit_enum_drop` rather than a plain
+    /// `mux_rc_dec` - see `RcSlot`.
+    pub(super) fn track_enum_variable(
+        &mut self,
+        name: &str,
+        enum_name: &str,
+        alloca: PointerValue<'a>,
+    ) {
+        if let Some(current_scope) = self.rc_scope_stack.last_mut() {
+            if current_scope
+                .iter()
+                .any(|(_, slot)| slot.alloca() == alloca)
+            {
+                return;
+            }
+            current_scope.push((
+                name.to_string(),
+                RcSlot::EnumStruct {
+                    enum_name: enum_name.to_string(),
+                    alloca,
+                },
+            ));
+        }
+    }
+
+    /// If `ty` is a user-declared enum (not the built-in `optional`/`result`,
+    /// which are boxed `*mut Value`s rather than inline structs), return its
+    /// name. Used to decide whether a struct-valued local needs enum drop-glue.
+    pub(super) fn user_enum_type_name(&self, ty: &Type) -> Option<String> {
+        let Type::Named(name, _) = ty else {
+            return None;
+        };
+        if name == "optional" || name == "result" {
+            return None;
+        }
+        self.enum_variants.contains_key(name).then(|| name.clone())
+    }
+
+    /// Whether any variant of `enum_name` carries at least one pointer (RC)
+    /// payload field. Enums that only hold inline scalars (a plain C-style enum)
+    /// own nothing and need no drop-glue, so tracking and `emit_enum_drop` skip
+    /// them entirely.
+    pub(super) fn enum_has_rc_payload(&self, enum_name: &str) -> bool {
+        let Some(variants) = self.enum_variants.get(enum_name).cloned() else {
+            return false;
+        };
+        variants.iter().any(|variant| {
+            self.variant_field_types(enum_name, variant)
+                .map(|fields| {
+                    (0..fields.len()).any(|i| {
+                        self.variant_field_llvm_type(enum_name, variant, &fields, i)
+                            .map(|t| t.is_pointer_type())
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        })
+    }
+
+    /// Release an inline enum value held at `struct_alloca` by decrementing only
+    /// the pointer payloads of its active variant. The variant is selected at
+    /// runtime by switching on the discriminant, mirroring construction, which
+    /// retains a payload only when it is a pointer (`rc_inc_if_pointer`): a union
+    /// slot typed as a pointer can hold a raw scalar for another variant, so an
+    /// unconditional decrement would corrupt memory. Scalar-only variants fall
+    /// through to the merge block untouched. No-op for enums with no pointer
+    /// payloads.
+    pub(super) fn emit_enum_drop(
+        &mut self,
+        enum_name: &str,
+        struct_alloca: PointerValue<'a>,
+    ) -> Result<(), String> {
+        if !self.enum_has_rc_payload(enum_name) {
+            return Ok(());
+        }
+
+        let struct_type = self
+            .type_map
+            .get(enum_name)
+            .ok_or_else(|| format!("Enum {} not found in type map", enum_name))?
+            .into_struct_type();
+        let rc_dec = self
+            .runtime_function("mux_rc_dec")
+            .ok_or("mux_rc_dec not found")?;
+        let ptr_type = self.context.ptr_type(AddressSpace::default());
+
+        let current_block = self
+            .builder
+            .get_insert_block()
+            .ok_or("emit_enum_drop: builder has no insertion block")?;
+        let function = current_block
+            .get_parent()
+            .ok_or("emit_enum_drop: insertion block has no parent function")?;
+
+        // Load the discriminant (struct field 0).
+        let tag_ptr = self
+            .builder
+            .build_struct_gep(struct_type, struct_alloca, 0, "enum_drop_tag_ptr")
+            .map_err(|e| e.to_string())?;
+        let discriminant = self
+            .builder
+            .build_load(self.context.i32_type(), tag_ptr, "enum_drop_tag")
+            .map_err(|e| e.to_string())?
+            .into_int_value();
+
+        let merge_block = self.context.append_basic_block(function, "enum_drop_merge");
+
+        // One switch case per variant that actually owns a pointer payload.
+        let variants = self
+            .enum_variants
+            .get(enum_name)
+            .cloned()
+            .ok_or_else(|| format!("Enum {} has no variant list", enum_name))?;
+        let mut cases = Vec::new();
+        for variant in &variants {
+            let fields = self.variant_field_types(enum_name, variant)?;
+            let pointer_fields: Vec<usize> = (0..fields.len())
+                .filter(|&i| {
+                    self.variant_field_llvm_type(enum_name, variant, &fields, i)
+                        .map(|t| t.is_pointer_type())
+                        .unwrap_or(false)
+                })
+                .collect();
+            if pointer_fields.is_empty() {
+                continue;
+            }
+            let index = self.get_variant_index(enum_name, variant)?;
+            let case_block = self
+                .context
+                .append_basic_block(function, &format!("enum_drop_{}_{}", enum_name, variant));
+            self.builder.position_at_end(case_block);
+            for field_index in pointer_fields {
+                let data_ptr = self
+                    .builder
+                    .build_struct_gep(
+                        struct_type,
+                        struct_alloca,
+                        (field_index + 1) as u32,
+                        "enum_drop_field_ptr",
+                    )
+                    .map_err(|e| e.to_string())?;
+                let payload = self
+                    .builder
+                    .build_load(ptr_type, data_ptr, "enum_drop_payload")
+                    .map_err(|e| e.to_string())?;
+                self.builder
+                    .build_call(rc_dec, &[payload.into()], "enum_drop_dec")
+                    .map_err(|e| e.to_string())?;
+            }
+            self.builder
+                .build_unconditional_branch(merge_block)
+                .map_err(|e| e.to_string())?;
+            cases.push((
+                self.context.i32_type().const_int(index as u64, false),
+                case_block,
+            ));
+        }
+
+        // Emit the switch on the original block, then continue at the merge.
+        self.builder.position_at_end(current_block);
+        self.builder
+            .build_switch(discriminant, merge_block, &cases)
+            .map_err(|e| e.to_string())?;
+        self.builder.position_at_end(merge_block);
+        Ok(())
     }
 
     /// Track a closure-typed variable in the current scope. Its slot will have

--- a/mux-compiler/src/codegen/mod.rs
+++ b/mux-compiler/src/codegen/mod.rs
@@ -31,6 +31,30 @@ use crate::semantics::{GenericContext, SemanticAnalyzer, Type, Type as ResolvedT
 type ClassTypeParamBounds = Vec<(String, Vec<(String, Vec<Type>)>)>;
 type EnumVariantFieldMap = HashMap<String, HashMap<String, Vec<EnumVariantField>>>;
 
+/// What a tracked RC scope slot holds, so end-of-scope cleanup releases it the
+/// right way. A boxed value is a `*mut Value` decremented directly; a custom
+/// enum is stored inline as a `{ i32 tag, fields... }` struct, so it needs
+/// variant-tag drop-glue to release only the pointer payloads of its active
+/// variant (see `emit_enum_drop`).
+#[derive(Clone)]
+pub(super) enum RcSlot<'a> {
+    Boxed(PointerValue<'a>),
+    EnumStruct {
+        enum_name: String,
+        alloca: PointerValue<'a>,
+    },
+}
+
+impl<'a> RcSlot<'a> {
+    /// The storage slot backing this entry, used to dedupe tracking so one slot
+    /// is never released twice within a scope.
+    fn alloca(&self) -> PointerValue<'a> {
+        match self {
+            RcSlot::Boxed(alloca) | RcSlot::EnumStruct { alloca, .. } => *alloca,
+        }
+    }
+}
+
 pub struct CodeGenerator<'a> {
     context: &'a Context,
     module: Module<'a>,
@@ -73,7 +97,7 @@ pub struct CodeGenerator<'a> {
     generic_context: Option<GenericContext>,
     context_stack: Vec<GenericContext>,
     generated_methods: HashMap<String, bool>,
-    rc_scope_stack: Vec<Vec<(String, PointerValue<'a>)>>,
+    rc_scope_stack: Vec<Vec<(String, RcSlot<'a>)>>,
     /// Owned RC temporaries produced during the current statement's expression
     /// evaluation that have not been bound to a variable. They are decremented
     /// at the statement boundary so intermediate values (string literals,

--- a/mux-compiler/src/codegen/statements.rs
+++ b/mux-compiler/src/codegen/statements.rs
@@ -36,6 +36,12 @@ impl<'a> CodeGenerator<'a> {
 
         if let Some((existing_ptr, _, _)) = existing_var {
             if value.is_struct_value() {
+                // NOTE: reassigning an inline enum struct into an existing slot
+                // does not yet release the previous value's pointer payloads, so
+                // enum reassignment and loop-rebind leak them (tracked as a known
+                // limitation; the initial-binding and global-teardown paths are
+                // handled). A complete fix needs zero-initialized enum slots plus
+                // drop-before-store here and in assign_to_identifier.
                 self.builder
                     .build_store(existing_ptr, value)
                     .map_err(|e| e.to_string())?;
@@ -60,6 +66,15 @@ impl<'a> CodeGenerator<'a> {
                 .map_err(|e| e.to_string())?;
             self.variables
                 .insert(name.to_string(), (alloca, var_type, resolved_type.clone()));
+            // Inline enum structs own the pointer payloads of their active
+            // variant; track the slot so those payloads are released when the
+            // scope ends. Plain value structs (classes are boxed, not inline)
+            // and scalar-only enums own nothing here and are skipped.
+            if let Some(enum_name) = self.user_enum_type_name(resolved_type)
+                && self.enum_has_rc_payload(&enum_name)
+            {
+                self.track_enum_variable(name, &enum_name, alloca);
+            }
         } else if let Some(func) = function {
             // Hoisted, null-initialized entry-block slot: because the store below
             // runs on every pass (e.g. a variable declared inside a loop body),
@@ -1590,7 +1605,7 @@ impl<'a> CodeGenerator<'a> {
         Ok(())
     }
 
-    fn variant_field_types(
+    pub(super) fn variant_field_types(
         &self,
         enum_name: &str,
         variant_name: &str,
@@ -1605,7 +1620,7 @@ impl<'a> CodeGenerator<'a> {
             .ok_or_else(|| format!("Variant {} not found in enum {}", variant_name, enum_name))
     }
 
-    fn variant_field_llvm_type(
+    pub(super) fn variant_field_llvm_type(
         &self,
         enum_name: &str,
         variant_name: &str,


### PR DESCRIPTION
## What

Fixes a memory leak: custom enum values did not release their heap payloads at
teardown. Adds variant-tag drop-glue (`emit_enum_drop`) for the scope-cleanup
and global-teardown paths.

## Background

Enum values are stored inline as a `{ i32 tag, fields... }` struct. Scope cleanup
(`generate_cleanup_for_vars`) and global teardown (`collect_teardown_slots`) both
skipped them because they are not boxed `*mut Value`s - so an enum holding a
`string` / `list` / `map` / `set` payload leaked that payload at exit.

This is the "still reachable" class that Valgrind's `definite,indirect` policy
ignores (a value held at refcount 1 is reachable, not lost) - the same shape as
#284. The new `rc-leak-check` runtime feature caught it: `enum_mixed_types`
leaked 8 blocks.

## How

- `emit_enum_drop` loads the discriminant, switches on it, and decrefs **only**
  the pointer payload fields of the active variant. This mirrors construction
  (`rc_inc_if_pointer`), which retains a payload only when it is a pointer - a
  union slot typed as a pointer can hold a raw scalar for another variant, so an
  unconditional decref would corrupt memory. Enums with no pointer payloads are
  a no-op.
- `RcSlot` tags each tracked cleanup slot as either a boxed `*mut Value` or an
  inline enum struct, so the shared cleanup paths dispatch correctly. Enum locals
  are tracked at their binding site; enum module-globals via
  `collect_teardown_slots`.

## Validation

- All `executable_integration` snapshots pass (output unchanged).
- The full `test_scripts` suite (97 programs + `error_cases`) is leak-clean under
  the `rc-leak-check` runtime, with no double-frees.

## Known limitation

Reassigning an enum local (`s = ...`) or rebinding one in a loop still leaks the
previous value's payload - tracked in #290 (needs zero-initialized enum slots
plus drop-before-store). The initial-binding and global paths are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
