### PR TITLE
Add Valgrind still-reachable regression check for module globals

### DIFF
--- a/infra/valgrind-globals/.gitignore
+++ b/infra/valgrind-globals/.gitignore
@@ -1,0 +1,5 @@
+# Build artifacts from Leg C fixture compilation; only the .mux sources are tracked.
+probe
+control
+consts_module
+*.ll

--- a/infra/valgrind-globals/consts_module.mux
+++ b/infra/valgrind-globals/consts_module.mux
@@ -1,0 +1,7 @@
+// Imported module carrying heap-allocated, module-private constants (a string,
+// a list, and a map). probe.mux reads these so the still-reachable check covers
+// cross-module global teardown, the exact shape of mux-compiler#284 where every
+// module-private constant sat at a permanent refcount of 1 and was never freed.
+const string BANNER = "imported banner text"
+const list<int> WEIGHTS = [3, 5, 7, 11, 13]
+const map<string, int> TABLE = {"one": 1, "two": 2, "three": 3}

--- a/infra/valgrind-globals/control.mux
+++ b/infra/valgrind-globals/control.mux
@@ -1,0 +1,21 @@
+// Control fixture for the Valgrind still-reachable regression check. It builds
+// the same runtime surface as probe.mux (a string, two lists, a map) but keeps
+// every value in locals with no module-level constants and no imports, so all
+// of it is released by ordinary scope teardown. Its "still reachable" total is
+// therefore the fixed runtime baseline. Leg C asserts probe.mux matches it; any
+// difference is leaked module globals.
+func main() returns void {
+    auto local_label = "probe local constant"
+    auto local_seq = [2, 4, 6, 8]
+    auto local_table = {"x": 10, "y": 20}
+    auto banner = "imported banner text"
+    auto weights = [3, 5, 7, 11, 13]
+    auto table = {"one": 1, "two": 2, "three": 3}
+    print(local_label)
+    print(local_seq[0].to_string())
+    print(local_table["x"].to_string())
+    print(banner)
+    print(weights[0].to_string())
+    print(table["one"].to_string())
+    return
+}

--- a/infra/valgrind-globals/probe.mux
+++ b/infra/valgrind-globals/probe.mux
@@ -4,6 +4,11 @@
 // and cross-module global teardown. If that teardown regresses (mux-compiler
 // #284), these constants stay reachable at exit and the program's
 // "still reachable" byte total rises above control.mux's fixed baseline.
+//
+// NOTE: probe.mux uses `import consts_module.*` whereas control.mux imports
+// nothing. Leg C's validity assumes module-import bookkeeping itself adds zero
+// extra "still reachable" bytes after correct teardown. If that invariant is
+// ever violated, the baseline comparison diverges spuriously.
 import consts_module.*
 
 const string LOCAL_LABEL = "probe local constant"

--- a/infra/valgrind-globals/probe.mux
+++ b/infra/valgrind-globals/probe.mux
@@ -1,0 +1,21 @@
+// Probe fixture for the Valgrind still-reachable regression check (Leg C of
+// scripts/valgrind-checks.sh). It holds its own module-private heap constants
+// and reads imported ones from consts_module.mux, exercising both same-module
+// and cross-module global teardown. If that teardown regresses (mux-compiler
+// #284), these constants stay reachable at exit and the program's
+// "still reachable" byte total rises above control.mux's fixed baseline.
+import consts_module.*
+
+const string LOCAL_LABEL = "probe local constant"
+const list<int> LOCAL_SEQ = [2, 4, 6, 8]
+const map<string, int> LOCAL_TABLE = {"x": 10, "y": 20}
+
+func main() returns void {
+    print(LOCAL_LABEL)
+    print(LOCAL_SEQ[0].to_string())
+    print(LOCAL_TABLE["x"].to_string())
+    print(BANNER)
+    print(WEIGHTS[0].to_string())
+    print(TABLE["one"].to_string())
+    return
+}

--- a/scripts/valgrind-checks.sh
+++ b/scripts/valgrind-checks.sh
@@ -263,8 +263,12 @@ measure_still_reachable() {
 
   # Run in the fixture directory so relative imports resolve. still-reachable is
   # deterministic, so no exit-code handling is needed here - only the report.
+  local rc=0
   ( cd "$dir" && timeout "$program_timeout" valgrind "${globals_valgrind_flags[@]}" "./$name" ) \
-    >/dev/null 2>"$log" || true
+    >/dev/null 2>"$log" || rc=$?
+  if [[ "$rc" -eq 124 ]]; then
+    echo "Leg C: timed out after ${program_timeout}s running $name (fixture may have hung)" >&2
+  fi
   rm -f "$bin" "$ll"
 
   bytes="$(grep -m1 'still reachable:' "$log" |
@@ -299,7 +303,13 @@ run_leg_globals() {
   echo "  control.mux still reachable: ${control_bytes} bytes"
   if [[ "$probe_bytes" -ne "$control_bytes" ]]; then
     g_failure=1
-    echo "  FAIL: module constants add $((probe_bytes - control_bytes)) still-reachable bytes over baseline."
+    local delta=$(( probe_bytes - control_bytes ))
+    local abs_delta=$(( delta < 0 ? -delta : delta ))
+    if [[ "$delta" -gt 0 ]]; then
+      echo "  FAIL: module constants add ${abs_delta} still-reachable bytes over baseline."
+    else
+      echo "  FAIL: probe has ${abs_delta} fewer still-reachable bytes than control (unexpected; check fixtures)."
+    fi
     echo "        A module-private constant is not released at global teardown (see #284)."
   else
     echo "  PASS: module globals add no still-reachable bytes over baseline."

--- a/scripts/valgrind-checks.sh
+++ b/scripts/valgrind-checks.sh
@@ -307,10 +307,10 @@ run_leg_globals() {
     local abs_delta=$(( delta < 0 ? -delta : delta ))
     if [[ "$delta" -gt 0 ]]; then
       echo "  FAIL: module constants add ${abs_delta} still-reachable bytes over baseline."
+      echo "        A module-private constant is not released at global teardown (see #284)."
     else
       echo "  FAIL: probe has ${abs_delta} fewer still-reachable bytes than control (unexpected; check fixtures)."
     fi
-    echo "        A module-private constant is not released at global teardown (see #284)."
   else
     echo "  PASS: module globals add no still-reachable bytes over baseline."
   fi

--- a/scripts/valgrind-checks.sh
+++ b/scripts/valgrind-checks.sh
@@ -15,7 +15,19 @@ set -euo pipefail
 #     mux binary are hard to suppress precisely and are not the bug class we
 #     gate on. Promote it to fatal once its baseline is characterized.
 #
-# Usage: scripts/valgrind-checks.sh [--programs] [--compiler]   (default: both)
+#   Leg C (--globals): guard the module-global teardown regression from #284,
+#     where module-private constants sat at a permanent refcount of 1 and stayed
+#     "still reachable" at exit - a leak Leg A cannot see, since its policy
+#     ignores still-reachable memory (reachable is not lost). Leg C compiles two
+#     fixtures under infra/valgrind-globals/ - probe.mux (module-private heap
+#     constants, same-module and imported) and control.mux (the same runtime
+#     surface with no module constants) - and compares their "still reachable"
+#     byte totals. Both share the same fixed runtime buffer, so the totals match
+#     exactly when teardown is correct; a regression makes probe.mux exceed the
+#     baseline. Leg C is PR-blocking: a mismatch exits nonzero.
+#
+# Usage: scripts/valgrind-checks.sh [--programs] [--compiler] [--globals]
+#        (default: all three legs)
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
@@ -32,6 +44,16 @@ valgrind_flags=(
   --show-leak-kinds=definite,indirect
 )
 
+# Leg C needs the full leak report, not the pass/fail policy the other legs use:
+# it parses the "still reachable" summary line, so it must not run --quiet (which
+# hides the summary) and must not set --error-exitcode (still-reachable memory is
+# not an error to gate on directly - the byte comparison is what gates).
+# shellcheck disable=SC2054
+globals_valgrind_flags=(
+  --leak-check=full
+  --show-leak-kinds=all
+)
+
 # Compiled Mux programs hang on undefined behavior instead of crashing, and
 # Valgrind slows execution by ~20x, so every program run is time-boxed.
 program_timeout=120
@@ -44,29 +66,33 @@ compiler_sample_scripts=(
 )
 
 usage() {
-  echo "Usage: scripts/valgrind-checks.sh [--programs] [--compiler]"
+  echo "Usage: scripts/valgrind-checks.sh [--programs] [--compiler] [--globals]"
   echo "  --programs   Leg A only: compiled test programs (PR-blocking)."
   echo "  --compiler   Leg B only: the compiler itself (report-only)."
-  echo "  (no flags)   Run both legs."
+  echo "  --globals    Leg C only: module-global still-reachable check (PR-blocking)."
+  echo "  (no flags)   Run all three legs."
 }
 
 parse_args() {
   local arg
   run_programs=0
   run_compiler=0
+  run_globals=0
   while [[ $# -gt 0 ]]; do
     arg="$1"
     case "$arg" in
       --programs) run_programs=1 ;;
       --compiler) run_compiler=1 ;;
+      --globals) run_globals=1 ;;
       -h|--help) usage; exit 0 ;;
       *) echo "Unknown argument: $arg" >&2; usage >&2; exit 1 ;;
     esac
     shift
   done
-  if [[ "$run_programs" -eq 0 && "$run_compiler" -eq 0 ]]; then
+  if [[ "$run_programs" -eq 0 && "$run_compiler" -eq 0 && "$run_globals" -eq 0 ]]; then
     run_programs=1
     run_compiler=1
+    run_globals=1
   fi
 }
 
@@ -213,6 +239,73 @@ run_leg_b() {
   rm -rf "$tmp_dir"
 }
 
+# Compile one Leg C fixture in place (so its co-located imports resolve) and run
+# the binary under Valgrind, printing its "still reachable" byte total to stdout.
+# Diagnostics go to stderr; returns nonzero if the fixture cannot be compiled or
+# the total cannot be parsed. Removes the binary and IR it produces; imported
+# module artifacts are cleaned by the caller, which knows the fixture set.
+measure_still_reachable() {
+  local script="$1"
+  local dir name bin ll log bytes
+  dir="$(dirname "$script")"
+  name="$(basename "$script" .mux)"
+  bin="$dir/$name"
+  ll="$dir/$name.ll"
+  log="$(mktemp)"
+
+  rm -f "$bin" "$ll"
+  if ! "$mux_bin" build "$script" >"$log" 2>&1 || [[ ! -x "$bin" ]]; then
+    echo "Leg C: failed to compile fixture $script" >&2
+    cat "$log" >&2
+    rm -f "$bin" "$ll" "$log"
+    return 1
+  fi
+
+  # Run in the fixture directory so relative imports resolve. still-reachable is
+  # deterministic, so no exit-code handling is needed here - only the report.
+  ( cd "$dir" && timeout "$program_timeout" valgrind "${globals_valgrind_flags[@]}" "./$name" ) \
+    >/dev/null 2>"$log" || true
+  rm -f "$bin" "$ll"
+
+  bytes="$(grep -m1 'still reachable:' "$log" |
+    sed -E 's/.*still reachable:[[:space:]]*([0-9,]+).*/\1/' | tr -d ',')"
+  rm -f "$log"
+  if [[ -z "$bytes" ]]; then
+    echo "Leg C: could not parse 'still reachable' total for $script" >&2
+    return 1
+  fi
+  printf '%s' "$bytes"
+}
+
+run_leg_globals() {
+  echo
+  echo "=== Leg C: module-global still-reachable regression ==="
+  local fixtures_dir probe_bytes control_bytes
+  fixtures_dir="$repo_root/infra/valgrind-globals"
+  g_failure=0
+
+  probe_bytes="$(measure_still_reachable "$fixtures_dir/probe.mux")" || g_failure=1
+  control_bytes="$(measure_still_reachable "$fixtures_dir/control.mux")" || g_failure=1
+  # Clear artifacts the fixtures and their imported module leave behind.
+  rm -f "$fixtures_dir"/probe "$fixtures_dir"/control "$fixtures_dir"/consts_module \
+    "$fixtures_dir"/probe.ll "$fixtures_dir"/control.ll "$fixtures_dir"/consts_module.ll
+
+  if [[ "$g_failure" -ne 0 ]]; then
+    echo "  Leg C could not complete (see errors above)."
+    return
+  fi
+
+  echo "  probe.mux   still reachable: ${probe_bytes} bytes"
+  echo "  control.mux still reachable: ${control_bytes} bytes"
+  if [[ "$probe_bytes" -ne "$control_bytes" ]]; then
+    g_failure=1
+    echo "  FAIL: module constants add $((probe_bytes - control_bytes)) still-reachable bytes over baseline."
+    echo "        A module-private constant is not released at global teardown (see #284)."
+  else
+    echo "  PASS: module globals add no still-reachable bytes over baseline."
+  fi
+}
+
 main() {
   parse_args "$@"
   require_valgrind
@@ -231,14 +324,26 @@ main() {
   if [[ "$run_compiler" -eq 1 ]]; then
     run_leg_b
   fi
+  if [[ "$run_globals" -eq 1 ]]; then
+    run_leg_globals
+  fi
 
+  local exit_code=0
   if [[ "$run_programs" -eq 1 && "${a_failures:-0}" -gt 0 ]]; then
     echo
     echo "Leg A found ${a_failures} failing program(s)." >&2
-    exit 1
+    exit_code=1
   fi
-  echo
-  echo "Valgrind checks complete."
+  if [[ "$run_globals" -eq 1 && "${g_failure:-0}" -ne 0 ]]; then
+    echo
+    echo "Leg C failed (see the Leg C output above)." >&2
+    exit_code=1
+  fi
+  if [[ "$exit_code" -eq 0 ]]; then
+    echo
+    echo "Valgrind checks complete."
+  fi
+  exit "$exit_code"
 }
 
 main "$@"

--- a/scripts/valgrind-checks.sh
+++ b/scripts/valgrind-checks.sh
@@ -273,11 +273,13 @@ measure_still_reachable() {
 
   bytes="$(grep -m1 'still reachable:' "$log" |
     sed -E 's/.*still reachable:[[:space:]]*([0-9,]+).*/\1/' | tr -d ',')"
-  rm -f "$log"
   if [[ -z "$bytes" ]]; then
     echo "Leg C: could not parse 'still reachable' total for $script" >&2
+    cat "$log" >&2
+    rm -f "$log"
     return 1
   fi
+  rm -f "$log"
   printf '%s' "$bytes"
 }
 


### PR DESCRIPTION
## What

Adds a Valgrind leg (Leg C) that catches the "still reachable" leak class the
existing legs cannot - a value held at refcount 1 past teardown, the shape of
#284.

## Why

The Valgrind legs run with `--errors-for-leak-kinds=definite,indirect`, so a
module constant that is allocated, stored in a global slot, and never released is
still *reachable* at exit and passes. #284 was exactly this: module-private
constants stuck at refcount 1, invisible to CI.

## How

Leg C compiles two fixtures under `infra/valgrind-globals/`:
- `probe.mux` - carries module-private heap constants, both same-module and
  imported from `consts_module.mux`;
- `control.mux` - the same runtime surface with no module constants.

Both share the same fixed runtime buffer, so their "still reachable" totals match
exactly when teardown is correct. A regression makes the probe exceed the
control, and Leg C fails (PR-blocking). It runs by default alongside Legs A/B; no
absolute byte count is hardcoded.

Validated locally: healthy fixtures match (pass); a simulated regression and a
broken fixture both fail with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
