### PR TITLE
Emit an object file instead of handing clang textual IR

### DIFF
--- a/mux-compiler/src/codegen/mod.rs
+++ b/mux-compiler/src/codegen/mod.rs
@@ -14,6 +14,8 @@
 //! - statements: Statement code generation
 //! - types: Type conversion functions
 
+use std::fs;
+use std::io::Write;
 use std::path::Path;
 
 use inkwell::AddressSpace;
@@ -917,13 +919,20 @@ impl<'a> CodeGenerator<'a> {
         Ok(())
     }
 
-    /// Compile the module straight to a native object file.
+    /// Compile the module to a native object file.
     ///
     /// The alternative is writing `.ll` and having clang parse it back, which
     /// couples every install to a clang whose major version matches the LLVM
     /// this compiler links - textual IR is not stable across versions. Emitting
-    /// the object here removes that coupling entirely: whatever links the
-    /// result only has to understand object files.
+    /// the object here removes that coupling: whatever links the result only has
+    /// to understand object files.
+    ///
+    /// LLVM emits into memory rather than to a path, and this writes the bytes
+    /// itself with `create_new` (`O_CREAT|O_EXCL`). Handing LLVM a path would
+    /// mean a pathname resolved at write time, which is a symlink-replacement
+    /// target; creating the file exclusively means the only filesystem entry
+    /// involved is one this process made, and an existing file or symlink there
+    /// is an error rather than a redirect.
     pub fn emit_object_to_file(&self, filename: &str) -> Result<(), String> {
         self.module
             .verify()
@@ -936,8 +945,8 @@ impl<'a> CodeGenerator<'a> {
         let target = Target::from_triple(&triple)
             .map_err(|e| format!("no LLVM target for {}: {}", triple, e.to_string()))?;
 
-        // PIC because distributions default to position-independent executables;
-        // a non-PIC object fails to link against them.
+        // PIC because distributions default to position-independent
+        // executables; a non-PIC object fails to link against them.
         let machine = target
             .create_target_machine(
                 &triple,
@@ -957,9 +966,17 @@ impl<'a> CodeGenerator<'a> {
         self.module
             .set_data_layout(&machine.get_target_data().get_data_layout());
 
-        machine
-            .write_to_file(&self.module, FileType::Object, Path::new(filename))
-            .map_err(|e| format!("failed to write object file: {}", e.to_string()))
+        let object = machine
+            .write_to_memory_buffer(&self.module, FileType::Object)
+            .map_err(|e| format!("failed to emit object code: {}", e.to_string()))?;
+
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(Path::new(filename))
+            .map_err(|e| format!("failed to create {}: {}", filename, e))?;
+        file.write_all(object.as_slice())
+            .map_err(|e| format!("failed to write {}: {}", filename, e))
     }
 
     pub fn emit_ir_to_file(&self, filename: &str) -> Result<(), String> {

--- a/mux-compiler/src/codegen/mod.rs
+++ b/mux-compiler/src/codegen/mod.rs
@@ -14,9 +14,7 @@
 //! - statements: Statement code generation
 //! - types: Type conversion functions
 
-use std::fs;
 use std::io::Write;
-use std::path::Path;
 
 use inkwell::AddressSpace;
 use inkwell::OptimizationLevel;
@@ -927,13 +925,12 @@ impl<'a> CodeGenerator<'a> {
     /// the object here removes that coupling: whatever links the result only has
     /// to understand object files.
     ///
-    /// LLVM emits into memory rather than to a path, and this writes the bytes
-    /// itself with `create_new` (`O_CREAT|O_EXCL`). Handing LLVM a path would
-    /// mean a pathname resolved at write time, which is a symlink-replacement
-    /// target; creating the file exclusively means the only filesystem entry
-    /// involved is one this process made, and an existing file or symlink there
-    /// is an error rather than a redirect.
-    pub fn emit_object_to_file(&self, filename: &str) -> Result<(), String> {
+    /// LLVM emits into memory and the bytes go to an already-open handle, so no
+    /// path is resolved here at all. The caller created that file exclusively
+    /// (`create_new`), so the only filesystem entry involved is one it made -
+    /// there is no pathname for anything to swap between deciding to write and
+    /// writing.
+    pub fn emit_object(&self, out: &mut impl Write) -> Result<(), String> {
         self.module
             .verify()
             .map_err(|e| format!("LLVM module verification failed: {}", e.to_string()))?;
@@ -970,13 +967,8 @@ impl<'a> CodeGenerator<'a> {
             .write_to_memory_buffer(&self.module, FileType::Object)
             .map_err(|e| format!("failed to emit object code: {}", e.to_string()))?;
 
-        let mut file = fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(Path::new(filename))
-            .map_err(|e| format!("failed to create {}: {}", filename, e))?;
-        file.write_all(object.as_slice())
-            .map_err(|e| format!("failed to write {}: {}", filename, e))
+        out.write_all(object.as_slice())
+            .map_err(|e| format!("failed to write the object file: {}", e))
     }
 
     pub fn emit_ir_to_file(&self, filename: &str) -> Result<(), String> {

--- a/mux-compiler/src/codegen/mod.rs
+++ b/mux-compiler/src/codegen/mod.rs
@@ -14,10 +14,16 @@
 //! - statements: Statement code generation
 //! - types: Type conversion functions
 
+use std::path::Path;
+
 use inkwell::AddressSpace;
+use inkwell::OptimizationLevel;
 use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::module::Module;
+use inkwell::targets::{
+    CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine,
+};
 use inkwell::types::BasicTypeEnum;
 use inkwell::values::{BasicValueEnum, FunctionValue, PointerValue};
 use std::collections::HashMap;
@@ -909,6 +915,51 @@ impl<'a> CodeGenerator<'a> {
         self.generate_class_methods_for_all_nodes(main_module_nodes)?;
 
         Ok(())
+    }
+
+    /// Compile the module straight to a native object file.
+    ///
+    /// The alternative is writing `.ll` and having clang parse it back, which
+    /// couples every install to a clang whose major version matches the LLVM
+    /// this compiler links - textual IR is not stable across versions. Emitting
+    /// the object here removes that coupling entirely: whatever links the
+    /// result only has to understand object files.
+    pub fn emit_object_to_file(&self, filename: &str) -> Result<(), String> {
+        self.module
+            .verify()
+            .map_err(|e| format!("LLVM module verification failed: {}", e.to_string()))?;
+
+        Target::initialize_native(&InitializationConfig::default())
+            .map_err(|e| format!("failed to initialize the native target: {}", e))?;
+
+        let triple = TargetMachine::get_default_triple();
+        let target = Target::from_triple(&triple)
+            .map_err(|e| format!("no LLVM target for {}: {}", triple, e.to_string()))?;
+
+        // PIC because distributions default to position-independent executables;
+        // a non-PIC object fails to link against them.
+        let machine = target
+            .create_target_machine(
+                &triple,
+                &TargetMachine::get_host_cpu_name().to_string(),
+                &TargetMachine::get_host_cpu_features().to_string(),
+                OptimizationLevel::None,
+                RelocMode::PIC,
+                CodeModel::Default,
+            )
+            .ok_or_else(|| format!("failed to create a target machine for {}", triple))?;
+
+        // Stamp the module with the machine's own triple and layout. Nothing set
+        // them before, which is why clang reported "overriding the module target
+        // triple"; emitting directly, a mismatch would mean wrong ABI decisions
+        // rather than a warning.
+        self.module.set_triple(&triple);
+        self.module
+            .set_data_layout(&machine.get_target_data().get_data_layout());
+
+        machine
+            .write_to_file(&self.module, FileType::Object, Path::new(filename))
+            .map_err(|e| format!("failed to write object file: {}", e.to_string()))
     }
 
     pub fn emit_ir_to_file(&self, filename: &str) -> Result<(), String> {

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -942,41 +942,70 @@ fn report_clang_output_or_exit(
     }
 }
 
-/// A private path for the object file handed to the linker.
+/// A private directory to emit the object file into, and the path within it.
 ///
-/// Deliberately not `<source>.o`: that would overwrite a `foo.o` the user
-/// already had beside `foo.mux` and then delete it during cleanup, losing a
-/// file the compiler does not own. The name carries the process id and a
-/// monotonic counter so concurrent compiles - the test suite runs many at once -
-/// cannot collide either.
-fn scratch_object_path(stem: &str) -> String {
+/// Not `<source>.o`: that would overwrite a `foo.o` the user already had beside
+/// `foo.mux` and then delete it during cleanup, losing a file the compiler does
+/// not own.
+///
+/// Not a bare path in the shared temp directory either. A predictable name that
+/// LLVM opens without exclusive creation is a symlink-squatting target - a local
+/// process can pre-create it pointing at any file this user can write, and the
+/// emitted object lands there instead. So the *directory* is created
+/// exclusively: `create_dir` fails if the path exists at all, including as a
+/// symlink, and mode 0700 keeps anyone else from placing entries inside it
+/// afterwards. The object name within it can then be fixed and boring.
+fn scratch_object_dir() -> Result<PathBuf, String> {
     use std::sync::atomic::{AtomicU64, Ordering};
     static SEQ: AtomicU64 = AtomicU64::new(0);
 
-    let name = Path::new(stem)
-        .file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "mux_module".to_string());
-
-    env::temp_dir()
-        .join(format!(
-            "mux-{}-{}-{}.o",
-            name,
+    // Distinct candidates rather than secret ones: exclusive creation is what
+    // provides the safety, and the nanosecond clock only avoids self-collision
+    // between concurrent compiles.
+    for _ in 0..16 {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let candidate = env::temp_dir().join(format!(
+            "mux-{}-{}-{}",
             process::id(),
+            nanos,
             SEQ.fetch_add(1, Ordering::Relaxed)
-        ))
-        .to_string_lossy()
-        .into_owned()
+        ));
+
+        let mut builder = fs::DirBuilder::new();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::DirBuilderExt;
+            builder.mode(0o700);
+        }
+        match builder.create(&candidate) {
+            Ok(()) => return Ok(candidate),
+            // Taken already - by a concurrent compile or by a squatter. Either
+            // way, try a different name rather than writing into it.
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => {
+                return Err(format!(
+                    "failed to create a temporary directory at {}: {}",
+                    candidate.display(),
+                    e
+                ));
+            }
+        }
+    }
+
+    Err("could not create a temporary directory for the object file".to_string())
 }
 
-/// Delete the object file once it has been linked. It is a build artifact the
-/// user did not ask for, unlike the `.ll`, which is now only written when `-i`
-/// requested it and so is never cleaned up here.
+/// Delete the private directory holding the object file once it has been
+/// linked. It is a build artifact the user did not ask for, unlike the `.ll`,
+/// which is only written when `-i` requested it and so is never cleaned up here.
 ///
-/// Best-effort: a failure to remove a temporary file should not fail a
+/// Best-effort: failing to remove a temporary directory should not fail a
 /// successful compile.
-fn remove_object_file(object_file: &str) {
-    let _ = fs::remove_file(object_file);
+fn remove_scratch_dir(dir: &Path) {
+    let _ = fs::remove_dir_all(dir);
 }
 
 fn run_executable_or_exit(exe_file: &Path) {
@@ -1173,7 +1202,15 @@ fn main() {
         .trim_end_matches(".mux")
         .to_string();
     let ir_file = format!("{}.ll", stem);
-    let object_file = scratch_object_path(&stem);
+    let scratch_dir = match scratch_object_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            spinner::stop();
+            report_internal_compiler_error(&e);
+            process::exit(1);
+        }
+    };
+    let object_file = scratch_dir.join("module.o").to_string_lossy().into_owned();
     generate_object_or_exit(
         &mut codegen,
         &nodes,
@@ -1257,7 +1294,7 @@ fn main() {
     // Before interpreting the result: a spawn failure or a nonzero linker exit
     // ends the process inside the call below, so cleaning up afterwards would
     // leak the scratch object on exactly the paths that fail.
-    remove_object_file(&object_file);
+    remove_scratch_dir(&scratch_dir);
     report_clang_output_or_exit(linker_output, do_run, &file_path, &ir_file);
 
     if do_run {
@@ -1502,6 +1539,39 @@ mod tests {
             );
             std::fs::remove_dir_all(&dir).ok();
         }
+    }
+
+    /// The scratch directory must be created exclusively, because a bare
+    /// predictable path in a shared temp directory is a symlink-squatting
+    /// target: a local process pre-creates it pointing at a file this user can
+    /// write, and the object LLVM emits lands there instead. `create_dir` is
+    /// what prevents that - this pins that it refuses an existing symlink
+    /// rather than following it.
+    #[cfg(unix)]
+    #[test]
+    fn scratch_dir_creation_refuses_an_existing_symlink() {
+        let base = unique_tmp("scratch_squat");
+        std::fs::create_dir_all(&base).unwrap();
+        let target = base.join("attacker_target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let squatted = base.join("scratch");
+        std::os::unix::fs::symlink(&target, &squatted).unwrap();
+
+        let err = std::fs::DirBuilder::new()
+            .create(&squatted)
+            .expect_err("creating over an existing symlink must fail, not follow it");
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+
+        // Nothing was written through the symlink.
+        assert_eq!(std::fs::read_dir(&target).unwrap().count(), 0);
+
+        // A fresh name still succeeds, which is what the retry loop relies on.
+        let fresh = base.join("scratch-2");
+        std::fs::DirBuilder::new().create(&fresh).unwrap();
+        assert!(fresh.is_dir());
+
+        std::fs::remove_dir_all(&base).ok();
     }
 
     /// A release install puts the library in `../lib` relative to the binary,

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -835,7 +835,7 @@ fn generate_object_or_exit(
         // A codegen failure is an internal compiler bug, not a language-level
         // error in the user's program, so it gets the internal-error framing
         // rather than a bare message.
-        remove_scratch_object(object_file);
+        remove_scratch_object(object_file, object);
         report_internal_compiler_error(&format!("codegen error: {}", e));
         process::exit(1);
     }
@@ -845,13 +845,13 @@ fn generate_object_or_exit(
         && let Err(e) = codegen.emit_ir_to_file(ir_file)
     {
         spinner::stop();
-        remove_scratch_object(object_file);
+        remove_scratch_object(object_file, object);
         report_internal_compiler_error(&format!("failed to emit IR: {}", e));
         process::exit(1);
     }
     if let Err(e) = codegen.emit_object(object) {
         spinner::stop();
-        remove_scratch_object(object_file);
+        remove_scratch_object(object_file, object);
         report_internal_compiler_error(&format!("failed to emit object file: {}", e));
         process::exit(1);
     }
@@ -1007,16 +1007,43 @@ fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
     Err("could not create a temporary object file".to_string())
 }
 
-/// Remove the object file once it has been linked. It is a build artifact the
-/// user did not ask for, unlike the `.ll`, which is only written when `-i` asked
-/// for it and is never cleaned up here.
+/// Remove the object file once it has been linked, but only if the path still
+/// names the file this process created. It is a build artifact the user did not
+/// ask for, unlike the `.ll`, which is only written when `-i` asked for it and is
+/// never cleaned up here.
 ///
-/// `unlink` does not follow the final path component, so this removes this
-/// path's own entry and never anything it might point at.
+/// The identity check is the point. A path is not a file: if the entry were
+/// replaced after emission, unlinking the path would delete something this
+/// process never made. Comparing the open handle's `fstat` against the path's
+/// `lstat` - device and inode - leaves an entry that is no longer ours alone.
+/// `lstat` also does not follow symlinks, so a link is compared as a link rather
+/// than resolved.
+///
+/// This narrows rather than eliminates: between the comparison and the unlink the
+/// entry could still change, and closing that needs `unlinkat` against a retained
+/// directory descriptor, which `std` does not expose. Reaching it requires
+/// replacing a file in a sticky-bit temp directory, which only this user or root
+/// can do - and a process running as this user can already replace the compiler
+/// binary.
 ///
 /// Best-effort: failing to remove a temporary file must not fail an otherwise
 /// successful compile.
-fn remove_scratch_object(object_file: &str) {
+fn remove_scratch_object(object_file: &str, handle: &fs::File) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        let (Ok(ours), Ok(named)) = (handle.metadata(), fs::symlink_metadata(object_file)) else {
+            // Cannot establish identity, so cannot establish ownership.
+            return;
+        };
+        if ours.dev() != named.dev() || ours.ino() != named.ino() {
+            return;
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = handle;
+
     let _ = fs::remove_file(object_file);
 }
 
@@ -1241,8 +1268,15 @@ fn main() {
         &object_file,
         intermediate.then_some(ir_file.as_str()),
     );
-    // Close the handle so the linker reads a fully flushed file.
-    drop(object);
+    // Flushed, not closed: the handle is what proves at cleanup that the path
+    // still names the file emitted here. std opens with shared access on Windows
+    // too, so the linker can still read it.
+    if let Err(e) = object.sync_all() {
+        spinner::stop();
+        remove_scratch_object(&object_file, &object);
+        report_internal_compiler_error(&format!("failed to flush the object file: {}", e));
+        process::exit(1);
+    }
 
     // build executable
     // Use ./ prefix to ensure we run the local executable, not a system command
@@ -1313,7 +1347,7 @@ fn main() {
     // Before interpreting the result: a spawn failure or a nonzero linker exit
     // ends the process inside the call below, so cleaning up afterwards would
     // leak the scratch object on exactly the paths that fail.
-    remove_scratch_object(&object_file);
+    remove_scratch_object(&object_file, &object);
     report_clang_output_or_exit(linker_output, do_run, &file_path, &ir_file);
 
     if do_run {
@@ -1585,34 +1619,63 @@ mod tests {
         std::fs::remove_dir_all(&base).ok();
     }
 
-    /// Cleanup must not reach outside the path it was given. `unlink` does not
-    /// follow the final component, so a swapped entry loses the replacement link
-    /// itself and never what it points at - which is why the object lives
-    /// directly in the temp directory with no directory of ours in between: an
-    /// intermediate component *would* be traversed.
+    /// Cleanup must delete only the file emission created. The path is not the
+    /// file: if the entry has been replaced, unlinking the path would destroy
+    /// something this process never made. The handle's identity is what
+    /// distinguishes them.
     #[cfg(unix)]
     #[test]
-    fn scratch_object_cleanup_does_not_follow_a_replacement_symlink() {
-        let base = unique_tmp("obj_cleanup");
+    fn scratch_object_cleanup_spares_a_replaced_entry() {
+        let base = unique_tmp("obj_identity");
         std::fs::create_dir_all(&base).unwrap();
+        let path = base.join("scratch.o");
 
-        let bystander = base.join("someone_elses.o");
-        std::fs::write(&bystander, b"KEEP").unwrap();
+        // The file this process created, and its handle.
+        let handle = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap();
 
-        let object = base.join("scratch.o");
-        std::os::unix::fs::symlink(&bystander, &object).unwrap();
+        // Someone replaces the entry with a different regular file.
+        std::fs::remove_file(&path).unwrap();
+        std::fs::write(&path, b"NOT OURS").unwrap();
 
-        remove_scratch_object(object.to_str().unwrap());
+        remove_scratch_object(path.to_str().unwrap(), &handle);
 
-        assert!(
-            !object.exists() && std::fs::symlink_metadata(&object).is_err(),
-            "the replacement link itself should be gone"
-        );
         assert_eq!(
-            std::fs::read(&bystander).unwrap(),
-            b"KEEP",
-            "the link target must survive cleanup"
+            std::fs::read(&path).unwrap(),
+            b"NOT OURS",
+            "an entry the compiler did not create must survive cleanup"
         );
+
+        // A replacement symlink is likewise left alone, and never followed.
+        let bystander = base.join("bystander");
+        std::fs::write(&bystander, b"KEEP").unwrap();
+        let linked = base.join("linked.o");
+        let linked_handle = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&linked)
+            .unwrap();
+        std::fs::remove_file(&linked).unwrap();
+        std::os::unix::fs::symlink(&bystander, &linked).unwrap();
+        remove_scratch_object(linked.to_str().unwrap(), &linked_handle);
+        assert!(
+            std::fs::symlink_metadata(&linked).is_ok(),
+            "link left alone"
+        );
+        assert_eq!(std::fs::read(&bystander).unwrap(), b"KEEP");
+
+        // And the untouched case still cleans up.
+        let ours = base.join("ours.o");
+        let ours_handle = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&ours)
+            .unwrap();
+        remove_scratch_object(ours.to_str().unwrap(), &ours_handle);
+        assert!(!ours.exists(), "our own object should be removed");
 
         std::fs::remove_dir_all(&base).ok();
     }

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -823,34 +823,44 @@ fn analyze_semantics_or_exit(
 ///
 /// Only the object is on the critical path. The textual IR used to be, which is
 /// what tied an install to a clang matching this compiler's LLVM major.
-fn generate_object_or_exit(
+/// Returns rather than exiting, so the caller can release the object handle
+/// first. `process::exit` skips destructors, and on Windows that handle is what
+/// deletes the file - exiting while holding it would leave the object in the
+/// temp directory for good.
+fn generate_object(
     codegen: &mut codegen::CodeGenerator,
     nodes: &[ast::AstNode],
     object: &mut fs::File,
     ir_file: Option<&str>,
-) {
-    if let Err(e) = codegen.generate(nodes) {
-        spinner::stop();
-        // A codegen failure is an internal compiler bug, not a language-level
-        // error in the user's program, so it gets the internal-error framing
-        // rather than a bare message.
-        report_internal_compiler_error(&format!("codegen error: {}", e));
-        process::exit(1);
-    }
+) -> Result<(), String> {
+    // A codegen failure is an internal compiler bug, not a language-level error
+    // in the user's program, so callers give it the internal-error framing
+    // rather than a bare message.
+    codegen
+        .generate(nodes)
+        .map_err(|e| format!("codegen error: {}", e))?;
+
     // IR first: when the module is invalid, the emitted `.ll` is exactly what is
     // needed to debug it, and object emission verifies and would bail first.
-    if let Some(ir_file) = ir_file
-        && let Err(e) = codegen.emit_ir_to_file(ir_file)
-    {
-        spinner::stop();
-        report_internal_compiler_error(&format!("failed to emit IR: {}", e));
-        process::exit(1);
+    if let Some(ir_file) = ir_file {
+        codegen
+            .emit_ir_to_file(ir_file)
+            .map_err(|e| format!("failed to emit IR: {}", e))?;
     }
-    if let Err(e) = codegen.emit_object(object) {
-        spinner::stop();
-        report_internal_compiler_error(&format!("failed to emit object file: {}", e));
-        process::exit(1);
-    }
+
+    codegen
+        .emit_object(object)
+        .map_err(|e| format!("failed to emit object file: {}", e))?;
+
+    // The bytes must be on disk, and read from the start: on unix the handle
+    // becomes the linker's stdin, on Windows it is reopened by path.
+    object
+        .sync_all()
+        .and_then(|()| {
+            use std::io::Seek;
+            object.rewind()
+        })
+        .map_err(|e| format!("failed to finalize the object file: {}", e))
 }
 
 fn resolve_runtime_lib_dir_or_exit() -> PathBuf {
@@ -1252,21 +1262,18 @@ fn main() {
             process::exit(1);
         }
     };
-    generate_object_or_exit(
+    if let Err(e) = generate_object(
         &mut codegen,
         &nodes,
         &mut object,
         intermediate.then_some(ir_file.as_str()),
-    );
-    // Rewind rather than close: on unix the handle becomes the linker's stdin and
-    // is read from the start; on Windows it is held open so DELETE_ON_CLOSE fires
-    // once linking is done. Either way the bytes must be on disk first.
-    if let Err(e) = object.sync_all().and_then(|()| {
-        use std::io::Seek;
-        object.rewind()
-    }) {
+    ) {
+        // Release the handle before exiting. `process::exit` skips destructors,
+        // so on Windows - where closing the handle is what deletes the file -
+        // exiting while holding it would leave the object behind for good.
+        drop(object);
         spinner::stop();
-        report_internal_compiler_error(&format!("failed to finalize the object file: {}", e));
+        report_internal_compiler_error(&e);
         process::exit(1);
     }
 
@@ -1343,6 +1350,11 @@ fn main() {
         linker.stdin(Stdio::from(object));
     }
     let linker_output = linker.output();
+
+    // Unix moved the handle into the child's stdin above; elsewhere release it
+    // here, before a link failure can exit the process while it is still held.
+    #[cfg(not(unix))]
+    drop(object);
 
     spinner::stop();
     report_clang_output_or_exit(linker_output, do_run, &file_path, &ir_file);

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -942,6 +942,33 @@ fn report_clang_output_or_exit(
     }
 }
 
+/// A private path for the object file handed to the linker.
+///
+/// Deliberately not `<source>.o`: that would overwrite a `foo.o` the user
+/// already had beside `foo.mux` and then delete it during cleanup, losing a
+/// file the compiler does not own. The name carries the process id and a
+/// monotonic counter so concurrent compiles - the test suite runs many at once -
+/// cannot collide either.
+fn scratch_object_path(stem: &str) -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+
+    let name = Path::new(stem)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "mux_module".to_string());
+
+    env::temp_dir()
+        .join(format!(
+            "mux-{}-{}-{}.o",
+            name,
+            process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ))
+        .to_string_lossy()
+        .into_owned()
+}
+
 /// Delete the object file once it has been linked. It is a build artifact the
 /// user did not ask for, unlike the `.ll`, which is now only written when `-i`
 /// requested it and so is never cleaned up here.
@@ -1146,7 +1173,7 @@ fn main() {
         .trim_end_matches(".mux")
         .to_string();
     let ir_file = format!("{}.ll", stem);
-    let object_file = format!("{}.o", stem);
+    let object_file = scratch_object_path(&stem);
     generate_object_or_exit(
         &mut codegen,
         &nodes,

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -946,6 +946,10 @@ fn report_clang_output_or_exit(
     }
 }
 
+/// Name of the object file inside the scratch directory. Shared so cleanup
+/// removes exactly the file emission created.
+const SCRATCH_OBJECT_NAME: &str = "module.o";
+
 /// A private directory to emit the object file into, and the path within it.
 ///
 /// Not `<source>.o`: that would overwrite a `foo.o` the user already had beside
@@ -1002,14 +1006,23 @@ fn scratch_object_dir() -> Result<PathBuf, String> {
     Err("could not create a temporary directory for the object file".to_string())
 }
 
-/// Delete the private directory holding the object file once it has been
-/// linked. It is a build artifact the user did not ask for, unlike the `.ll`,
-/// which is only written when `-i` requested it and so is never cleaned up here.
+/// Remove exactly what was put in the scratch directory, then the directory
+/// itself. The object is a build artifact the user did not ask for, unlike the
+/// `.ll`, which is only written when `-i` requested it and is never cleaned up
+/// here.
 ///
-/// Best-effort: failing to remove a temporary directory should not fail a
-/// successful compile.
+/// Deliberately not `remove_dir_all`: that recursively deletes whatever is at
+/// the path, and the path is all this holds - if the directory it names is no
+/// longer the one this process created, a recursive delete would take unrelated
+/// data with it. Removing the single known file and then a non-recursive
+/// `remove_dir` cannot: `remove_dir` refuses a directory containing anything
+/// else, and refuses a symlink outright. Anything unexpected is left alone.
+///
+/// Best-effort throughout: failing to clean up a temporary file must not fail an
+/// otherwise successful compile.
 fn remove_scratch_dir(dir: &Path) {
-    let _ = fs::remove_dir_all(dir);
+    let _ = fs::remove_file(dir.join(SCRATCH_OBJECT_NAME));
+    let _ = fs::remove_dir(dir);
 }
 
 fn run_executable_or_exit(exe_file: &Path) {
@@ -1226,7 +1239,10 @@ fn main() {
             process::exit(1);
         }
     };
-    let object_file = scratch_dir.join("module.o").to_string_lossy().into_owned();
+    let object_file = scratch_dir
+        .join(SCRATCH_OBJECT_NAME)
+        .to_string_lossy()
+        .into_owned();
     generate_object_or_exit(
         &mut codegen,
         &nodes,
@@ -1318,9 +1334,9 @@ mod tests {
         REQUIRED_LLVM_MAJOR, clang_failure_detail, clang_version_output, compiling_file,
         dir_holding_runtime_lib, extract_clang_major, find_runtime_lib_in_dir, format_panic_detail,
         internal_compiler_error_report, llvm_config_candidates, pick_llvm_for_dev,
-        print_doctor_verdict, print_version_banner, relativize_to_cwd, report_clang_for_doctor,
-        report_runtime_for_doctor, runtime_lib_dir_is_static_only, set_compiling_file,
-        status_marker, validate_llvm_for_doctor,
+        print_doctor_verdict, print_version_banner, relativize_to_cwd, remove_scratch_dir,
+        report_clang_for_doctor, report_runtime_for_doctor, runtime_lib_dir_is_static_only,
+        set_compiling_file, status_marker, validate_llvm_for_doctor,
     };
     use std::path::{Path, PathBuf};
 
@@ -1549,6 +1565,43 @@ mod tests {
             );
             std::fs::remove_dir_all(&dir).ok();
         }
+    }
+
+    /// Cleanup must remove only what emission created. The scratch path is all
+    /// the compiler holds, so if the directory it names is no longer the one
+    /// this process made, a recursive delete would take unrelated data with it.
+    /// This pins that a directory holding anything else survives.
+    #[test]
+    fn scratch_cleanup_leaves_a_replaced_directory_alone() {
+        let base = unique_tmp("scratch_replace");
+        std::fs::create_dir_all(&base).unwrap();
+
+        // Stand in for a directory that is not the one emission created: it has
+        // unrelated contents and no object file.
+        let replacement = base.join("scratch");
+        std::fs::create_dir_all(&replacement).unwrap();
+        std::fs::write(replacement.join("someone_elses_data"), b"KEEP").unwrap();
+
+        remove_scratch_dir(&replacement);
+
+        assert!(
+            replacement.is_dir(),
+            "a directory holding unrelated files must survive cleanup"
+        );
+        assert_eq!(
+            std::fs::read(replacement.join("someone_elses_data")).unwrap(),
+            b"KEEP"
+        );
+
+        // The directory this process did create - one object file, nothing else -
+        // is removed completely.
+        let ours = base.join("ours");
+        std::fs::create_dir_all(&ours).unwrap();
+        std::fs::write(ours.join("module.o"), b"obj").unwrap();
+        remove_scratch_dir(&ours);
+        assert!(!ours.exists(), "our own scratch directory should be gone");
+
+        std::fs::remove_dir_all(&base).ok();
     }
 
     /// The object file is created exclusively too, not just the directory

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -1251,12 +1251,14 @@ fn main() {
             .to_string(),
     );
 
-    let clang_output = Command::new(&linker_cmd).args(&linker_args).output();
+    let linker_output = Command::new(&linker_cmd).args(&linker_args).output();
 
     spinner::stop();
-    report_clang_output_or_exit(clang_output, do_run, &file_path, &ir_file);
-
+    // Before interpreting the result: a spawn failure or a nonzero linker exit
+    // ends the process inside the call below, so cleaning up afterwards would
+    // leak the scratch object on exactly the paths that fail.
     remove_object_file(&object_file);
+    report_clang_output_or_exit(linker_output, do_run, &file_path, &ir_file);
 
     if do_run {
         run_executable_or_exit(&exe_file);

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -987,11 +987,20 @@ fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
             SEQ.fetch_add(1, Ordering::Relaxed)
         ));
 
-        match fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&candidate)
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(windows)]
         {
+            // FILE_FLAG_DELETE_ON_CLOSE: the OS removes the file when the last
+            // handle closes, so Windows needs no delete-by-path at all - and so
+            // has no pathname that could be replaced between check and unlink.
+            // std's default share mode includes FILE_SHARE_DELETE, so the linker
+            // can still read it while this handle is open.
+            use std::os::windows::fs::OpenOptionsExt;
+            const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x0400_0000;
+            options.custom_flags(FILE_FLAG_DELETE_ON_CLOSE);
+        }
+        match options.open(&candidate) {
             Ok(file) => return Ok((candidate.to_string_lossy().into_owned(), file)),
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(e) => {
@@ -1019,33 +1028,40 @@ fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
 /// `lstat` also does not follow symlinks, so a link is compared as a link rather
 /// than resolved.
 ///
-/// This narrows rather than eliminates: between the comparison and the unlink the
-/// entry could still change, and closing that needs `unlinkat` against a retained
-/// directory descriptor, which `std` does not expose. Reaching it requires
-/// replacing a file in a sticky-bit temp directory, which only this user or root
-/// can do - and a process running as this user can already replace the compiler
-/// binary.
+/// A residual window remains between the comparison and the unlink, and it is not
+/// closeable: POSIX has no unlink-by-descriptor, and `unlinkat` still resolves the
+/// final path component, so a directory descriptor would not help either. Only
+/// FreeBSD's `funlinkat` compares against an open file, and Linux has no
+/// equivalent. Reaching that window also requires replacing a file in a
+/// sticky-bit temp directory, which only this user or root can do - and a process
+/// running as this user can already replace the compiler binary.
+///
+/// Windows does not take this path at all: the file is opened
+/// `FILE_FLAG_DELETE_ON_CLOSE`, so the OS removes it when the handle closes and
+/// there is no pathname to validate.
 ///
 /// Best-effort: failing to remove a temporary file must not fail an otherwise
 /// successful compile.
+#[cfg(unix)]
 fn remove_scratch_object(object_file: &str, handle: &fs::File) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
+    use std::os::unix::fs::MetadataExt;
 
-        let (Ok(ours), Ok(named)) = (handle.metadata(), fs::symlink_metadata(object_file)) else {
-            // Cannot establish identity, so cannot establish ownership.
-            return;
-        };
-        if ours.dev() != named.dev() || ours.ino() != named.ino() {
-            return;
-        }
+    let (Ok(ours), Ok(named)) = (handle.metadata(), fs::symlink_metadata(object_file)) else {
+        // Cannot establish identity, so cannot establish ownership.
+        return;
+    };
+    if ours.dev() != named.dev() || ours.ino() != named.ino() {
+        return;
     }
-    #[cfg(not(unix))]
-    let _ = handle;
 
     let _ = fs::remove_file(object_file);
 }
+
+/// Nothing to do: the file was opened `FILE_FLAG_DELETE_ON_CLOSE`, so closing the
+/// handle removes it. Deleting by path here would reintroduce exactly the
+/// replaceable pathname that flag avoids.
+#[cfg(not(unix))]
+fn remove_scratch_object(_object_file: &str, _handle: &fs::File) {}
 
 fn run_executable_or_exit(exe_file: &Path) {
     let run_path = if exe_file.is_absolute() {

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -827,7 +827,6 @@ fn generate_object_or_exit(
     codegen: &mut codegen::CodeGenerator,
     nodes: &[ast::AstNode],
     object: &mut fs::File,
-    object_file: &str,
     ir_file: Option<&str>,
 ) {
     if let Err(e) = codegen.generate(nodes) {
@@ -835,7 +834,6 @@ fn generate_object_or_exit(
         // A codegen failure is an internal compiler bug, not a language-level
         // error in the user's program, so it gets the internal-error framing
         // rather than a bare message.
-        remove_scratch_object(object_file, object);
         report_internal_compiler_error(&format!("codegen error: {}", e));
         process::exit(1);
     }
@@ -845,13 +843,11 @@ fn generate_object_or_exit(
         && let Err(e) = codegen.emit_ir_to_file(ir_file)
     {
         spinner::stop();
-        remove_scratch_object(object_file, object);
         report_internal_compiler_error(&format!("failed to emit IR: {}", e));
         process::exit(1);
     }
     if let Err(e) = codegen.emit_object(object) {
         spinner::stop();
-        remove_scratch_object(object_file, object);
         report_internal_compiler_error(&format!("failed to emit object file: {}", e));
         process::exit(1);
     }
@@ -946,7 +942,13 @@ fn report_clang_output_or_exit(
     }
 }
 
-/// An exclusively created path for the object file, plus its open handle.
+/// How the linker refers to an object it reads from inherited stdin. `/dev/fd` is
+/// standard on Linux and the BSDs, macOS included, and `/dev/stdin` is the
+/// descriptor-0 entry within it.
+#[cfg(unix)]
+const LINKER_STDIN_OBJECT: &str = "/dev/stdin";
+
+/// An open handle to the object file, and the argument naming it to the linker.
 ///
 /// A file directly in the temp directory, with no directory of our own in
 /// between. Two properties make that safe, and an intermediate component would
@@ -1001,7 +1003,27 @@ fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
             options.custom_flags(FILE_FLAG_DELETE_ON_CLOSE);
         }
         match options.open(&candidate) {
-            Ok(file) => return Ok((candidate.to_string_lossy().into_owned(), file)),
+            Ok(file) => {
+                #[cfg(unix)]
+                {
+                    // Drop the name straight away. From here the object exists
+                    // only as this descriptor, so there is no path for anything
+                    // to replace and nothing to unlink afterwards - the file is
+                    // released when the descriptor closes. The linker reads it as
+                    // `/dev/stdin`, which is why the handle becomes the child's
+                    // stdin rather than being closed here.
+                    if let Err(e) = fs::remove_file(&candidate) {
+                        return Err(format!(
+                            "failed to unlink the temporary object file {}: {}",
+                            candidate.display(),
+                            e
+                        ));
+                    }
+                    return Ok((LINKER_STDIN_OBJECT.to_string(), file));
+                }
+                #[cfg(not(unix))]
+                return Ok((candidate.to_string_lossy().into_owned(), file));
+            }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(e) => {
                 return Err(format!(
@@ -1015,53 +1037,6 @@ fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
 
     Err("could not create a temporary object file".to_string())
 }
-
-/// Remove the object file once it has been linked, but only if the path still
-/// names the file this process created. It is a build artifact the user did not
-/// ask for, unlike the `.ll`, which is only written when `-i` asked for it and is
-/// never cleaned up here.
-///
-/// The identity check is the point. A path is not a file: if the entry were
-/// replaced after emission, unlinking the path would delete something this
-/// process never made. Comparing the open handle's `fstat` against the path's
-/// `lstat` - device and inode - leaves an entry that is no longer ours alone.
-/// `lstat` also does not follow symlinks, so a link is compared as a link rather
-/// than resolved.
-///
-/// A residual window remains between the comparison and the unlink, and it is not
-/// closeable: POSIX has no unlink-by-descriptor, and `unlinkat` still resolves the
-/// final path component, so a directory descriptor would not help either. Only
-/// FreeBSD's `funlinkat` compares against an open file, and Linux has no
-/// equivalent. Reaching that window also requires replacing a file in a
-/// sticky-bit temp directory, which only this user or root can do - and a process
-/// running as this user can already replace the compiler binary.
-///
-/// Windows does not take this path at all: the file is opened
-/// `FILE_FLAG_DELETE_ON_CLOSE`, so the OS removes it when the handle closes and
-/// there is no pathname to validate.
-///
-/// Best-effort: failing to remove a temporary file must not fail an otherwise
-/// successful compile.
-#[cfg(unix)]
-fn remove_scratch_object(object_file: &str, handle: &fs::File) {
-    use std::os::unix::fs::MetadataExt;
-
-    let (Ok(ours), Ok(named)) = (handle.metadata(), fs::symlink_metadata(object_file)) else {
-        // Cannot establish identity, so cannot establish ownership.
-        return;
-    };
-    if ours.dev() != named.dev() || ours.ino() != named.ino() {
-        return;
-    }
-
-    let _ = fs::remove_file(object_file);
-}
-
-/// Nothing to do: the file was opened `FILE_FLAG_DELETE_ON_CLOSE`, so closing the
-/// handle removes it. Deleting by path here would reintroduce exactly the
-/// replaceable pathname that flag avoids.
-#[cfg(not(unix))]
-fn remove_scratch_object(_object_file: &str, _handle: &fs::File) {}
 
 fn run_executable_or_exit(exe_file: &Path) {
     let run_path = if exe_file.is_absolute() {
@@ -1281,16 +1256,17 @@ fn main() {
         &mut codegen,
         &nodes,
         &mut object,
-        &object_file,
         intermediate.then_some(ir_file.as_str()),
     );
-    // Flushed, not closed: the handle is what proves at cleanup that the path
-    // still names the file emitted here. std opens with shared access on Windows
-    // too, so the linker can still read it.
-    if let Err(e) = object.sync_all() {
+    // Rewind rather than close: on unix the handle becomes the linker's stdin and
+    // is read from the start; on Windows it is held open so DELETE_ON_CLOSE fires
+    // once linking is done. Either way the bytes must be on disk first.
+    if let Err(e) = object.sync_all().and_then(|()| {
+        use std::io::Seek;
+        object.rewind()
+    }) {
         spinner::stop();
-        remove_scratch_object(&object_file, &object);
-        report_internal_compiler_error(&format!("failed to flush the object file: {}", e));
+        report_internal_compiler_error(&format!("failed to finalize the object file: {}", e));
         process::exit(1);
     }
 
@@ -1357,13 +1333,18 @@ fn main() {
             .to_string(),
     );
 
-    let linker_output = Command::new(&linker_cmd).args(&linker_args).output();
+    let mut linker = Command::new(&linker_cmd);
+    linker.args(&linker_args);
+    #[cfg(unix)]
+    {
+        // `/dev/stdin` in linker_args refers to this descriptor. Moving the
+        // handle in also closes this process's copy once the child has it, so the
+        // file is released as soon as linking finishes - no cleanup path at all.
+        linker.stdin(Stdio::from(object));
+    }
+    let linker_output = linker.output();
 
     spinner::stop();
-    // Before interpreting the result: a spawn failure or a nonzero linker exit
-    // ends the process inside the call below, so cleaning up afterwards would
-    // leak the scratch object on exactly the paths that fail.
-    remove_scratch_object(&object_file, &object);
     report_clang_output_or_exit(linker_output, do_run, &file_path, &ir_file);
 
     if do_run {
@@ -1377,9 +1358,9 @@ mod tests {
         REQUIRED_LLVM_MAJOR, clang_failure_detail, clang_version_output, compiling_file,
         dir_holding_runtime_lib, extract_clang_major, find_runtime_lib_in_dir, format_panic_detail,
         internal_compiler_error_report, llvm_config_candidates, pick_llvm_for_dev,
-        print_doctor_verdict, print_version_banner, relativize_to_cwd, remove_scratch_object,
-        report_clang_for_doctor, report_runtime_for_doctor, runtime_lib_dir_is_static_only,
-        set_compiling_file, status_marker, validate_llvm_for_doctor,
+        print_doctor_verdict, print_version_banner, relativize_to_cwd, report_clang_for_doctor,
+        report_runtime_for_doctor, runtime_lib_dir_is_static_only, set_compiling_file,
+        status_marker, validate_llvm_for_doctor,
     };
     use std::path::{Path, PathBuf};
 
@@ -1631,67 +1612,6 @@ mod tests {
             .expect_err("create_new must refuse an existing symlink, not follow it");
         assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
         assert_eq!(std::fs::read(&victim).unwrap(), b"UNTOUCHED");
-
-        std::fs::remove_dir_all(&base).ok();
-    }
-
-    /// Cleanup must delete only the file emission created. The path is not the
-    /// file: if the entry has been replaced, unlinking the path would destroy
-    /// something this process never made. The handle's identity is what
-    /// distinguishes them.
-    #[cfg(unix)]
-    #[test]
-    fn scratch_object_cleanup_spares_a_replaced_entry() {
-        let base = unique_tmp("obj_identity");
-        std::fs::create_dir_all(&base).unwrap();
-        let path = base.join("scratch.o");
-
-        // The file this process created, and its handle.
-        let handle = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)
-            .unwrap();
-
-        // Someone replaces the entry with a different regular file.
-        std::fs::remove_file(&path).unwrap();
-        std::fs::write(&path, b"NOT OURS").unwrap();
-
-        remove_scratch_object(path.to_str().unwrap(), &handle);
-
-        assert_eq!(
-            std::fs::read(&path).unwrap(),
-            b"NOT OURS",
-            "an entry the compiler did not create must survive cleanup"
-        );
-
-        // A replacement symlink is likewise left alone, and never followed.
-        let bystander = base.join("bystander");
-        std::fs::write(&bystander, b"KEEP").unwrap();
-        let linked = base.join("linked.o");
-        let linked_handle = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&linked)
-            .unwrap();
-        std::fs::remove_file(&linked).unwrap();
-        std::os::unix::fs::symlink(&bystander, &linked).unwrap();
-        remove_scratch_object(linked.to_str().unwrap(), &linked_handle);
-        assert!(
-            std::fs::symlink_metadata(&linked).is_ok(),
-            "link left alone"
-        );
-        assert_eq!(std::fs::read(&bystander).unwrap(), b"KEEP");
-
-        // And the untouched case still cleans up.
-        let ours = base.join("ours.o");
-        let ours_handle = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&ours)
-            .unwrap();
-        remove_scratch_object(ours.to_str().unwrap(), &ours_handle);
-        assert!(!ours.exists(), "our own object should be removed");
 
         std::fs::remove_dir_all(&base).ok();
     }

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -93,7 +93,7 @@ enum Commands {
     Version {},
 }
 
-fn find_clang_command() -> Option<String> {
+fn find_linker_command() -> Option<String> {
     if let Ok(cc) = env::var("CC") {
         let output = Command::new(&cc).arg("--version").output();
         if output.is_ok_and(|o| o.status.success()) {
@@ -513,8 +513,8 @@ fn run_doctor(dev_mode: bool) {
 
     print_detected_llvm_versions(&llvm_versions);
     let llvm_ok = validate_llvm_for_doctor(dev_mode, selected_dev_llvm);
-    let clang = find_clang_command();
-    let clang_ok = report_clang_for_doctor(clang.as_deref());
+    let linker = find_linker_command();
+    let clang_ok = report_clang_for_doctor(linker.as_deref());
     let runtime_ok = ensure_runtime_for_doctor();
 
     if !print_doctor_verdict(llvm_ok && clang_ok && runtime_ok) {
@@ -522,9 +522,10 @@ fn run_doctor(dev_mode: bool) {
     }
 }
 
-fn get_clang_version() -> Option<String> {
-    let clang = find_clang_command()?;
-    let output = Command::new(&clang).arg("--version").output().ok()?;
+/// Version of the C driver used to link programs, for the version banner.
+fn get_linker_version() -> Option<String> {
+    let linker = find_linker_command()?;
+    let output = Command::new(&linker).arg("--version").output().ok()?;
     if !output.status.success() {
         return None;
     }
@@ -688,7 +689,7 @@ fn banner_version_lines(green: anstyle::Style) -> Vec<String> {
         format!("{green}compiler{green:#} v{}", env!("CARGO_PKG_VERSION")),
         format!("{green}runtime{green:#} v{}", env!("MUX_RUNTIME_VERSION")),
     ];
-    if let Some(ref c) = get_clang_version() {
+    if let Some(ref c) = get_linker_version() {
         version_lines.push(format!("{green}clang{green:#} v{c}"));
     }
     version_lines.push(format!("{green}llvm{green:#} v{}", get_llvm_version()));
@@ -870,13 +871,13 @@ fn resolve_runtime_lib_dir_or_exit() -> PathBuf {
     }
 }
 
-fn find_clang_or_exit() -> String {
-    match find_clang_command() {
+fn find_linker_or_exit() -> String {
+    match find_linker_command() {
         Some(cmd) => cmd,
         None => {
             spinner::stop();
-            eprintln!("clang is required to link Mux programs but was not found on PATH.");
-            print_llvm_install_help();
+            eprintln!("A C compiler is required to link Mux programs, and none was found.");
+            print_linker_install_help();
             process::exit(1);
         }
     }
@@ -1178,8 +1179,8 @@ fn main() {
         .to_str()
         .expect("library path should be valid Unicode");
 
-    let clang_cmd = find_clang_or_exit();
-    let mut clang_args = vec![
+    let linker_cmd = find_linker_or_exit();
+    let mut linker_args = vec![
         object_file.clone(),
         "-L".to_string(),
         lib_path_str.to_string(),
@@ -1189,15 +1190,15 @@ fn main() {
     ];
 
     #[cfg(not(target_os = "macos"))]
-    clang_args.push("-Wl,--disable-new-dtags".to_string());
+    linker_args.push("-Wl,--disable-new-dtags".to_string());
 
     let gc_sections_flag = if cfg!(target_os = "macos") {
         "-Wl,-dead_strip".to_string()
     } else {
         "-Wl,--gc-sections".to_string()
     };
-    clang_args.push(gc_sections_flag);
-    clang_args.push("-lmux_runtime".to_string());
+    linker_args.push(gc_sections_flag);
+    linker_args.push("-lmux_runtime".to_string());
 
     // A static-only libmux_runtime.a carries no NEEDED entries, so its undefined
     // native symbols must be resolved explicitly - otherwise a program using
@@ -1211,19 +1212,19 @@ fn main() {
         && runtime_lib_dir_is_static_only(&lib_dir)
     {
         for native_lib in ["-lm", "-lz", "-lpthread", "-ldl"] {
-            clang_args.push(native_lib.to_string());
+            linker_args.push(native_lib.to_string());
         }
     }
 
-    clang_args.push("-o".to_string());
-    clang_args.push(
+    linker_args.push("-o".to_string());
+    linker_args.push(
         exe_file
             .to_str()
             .expect("executable path should be valid Unicode")
             .to_string(),
     );
 
-    let clang_output = Command::new(&clang_cmd).args(&clang_args).output();
+    let clang_output = Command::new(&linker_cmd).args(&linker_args).output();
 
     spinner::stop();
     report_clang_output_or_exit(clang_output, do_run, &file_path, &ir_file);

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -101,9 +101,13 @@ fn find_clang_command() -> Option<String> {
         }
     }
 
+    // Any C driver can link an object file. The version used to matter because
+    // the compiler handed clang textual IR to parse; it emits an object now, so
+    // `cc` and `gcc` are just as valid and the search no longer needs a
+    // version-matched clang to exist.
     let linked_major = env!("MUX_LLVM_MAJOR");
     let versioned = format!("clang-{}", linked_major);
-    let candidates: &[&str] = &[versioned.as_str(), "clang"];
+    let candidates: &[&str] = &[versioned.as_str(), "clang", "cc", "gcc"];
     for candidate in candidates {
         let output = match Command::new(candidate).arg("--version").output() {
             Ok(output) => output,
@@ -170,6 +174,25 @@ fn pick_llvm_for_dev(versions: &[(String, String, u32)]) -> Option<(String, Stri
         .iter()
         .find(|(_, _, major)| *major == REQUIRED_LLVM_MAJOR)
         .map(|(tool, version, major)| (tool.clone(), version.clone(), *major))
+}
+
+/// Install help for the C driver used to link programs. Distinct from
+/// `print_llvm_install_help`, which is about the LLVM *development* libraries a
+/// source build of the compiler needs - linking a compiled program only needs a
+/// C toolchain, of any version.
+fn print_linker_install_help() {
+    if cfg!(target_os = "linux") {
+        println!("Install a C toolchain:");
+        println!("  Debian/Ubuntu: sudo apt-get install clang");
+        println!("  Arch Linux:    sudo pacman -S clang");
+        println!("Any recent clang or gcc works; the version does not need to match.");
+    } else if cfg!(target_os = "macos") {
+        println!("Install the Xcode command line tools:");
+        println!("  xcode-select --install");
+    } else if cfg!(target_family = "windows") {
+        println!("Install LLVM (which provides clang), for example via Chocolatey:");
+        println!("  choco install llvm");
+    }
 }
 
 fn print_llvm_install_help() {
@@ -391,46 +414,31 @@ fn validate_llvm_for_doctor(
     true
 }
 
-fn report_clang_for_doctor(clang: Option<&str>) -> bool {
-    if let Some(clang_cmd) = clang {
-        let linked_major: u32 = env!("MUX_LLVM_MAJOR")
-            .parse()
-            .unwrap_or(REQUIRED_LLVM_MAJOR);
-        let clang_ok = match extract_clang_major(clang_cmd) {
-            Some(clang_major) if clang_major == linked_major => {
-                println!(
-                    "{} Clang is installed: {} (matches linked LLVM {}).",
-                    status_marker(true),
-                    clang_cmd,
-                    linked_major
-                );
-                true
-            }
-            Some(clang_major) => {
-                println!(
-                    "{} {} (clang {}) does not match linked LLVM {}.",
-                    status_marker(false),
-                    clang_cmd,
-                    clang_major,
-                    linked_major
-                );
-                println!(
-                    "  This will cause IR parse errors. Install clang-{} or set CC=clang-{}.",
-                    linked_major, linked_major
-                );
-                false
-            }
-            None => {
-                println!("{} Clang is installed: {}.", status_marker(true), clang_cmd);
-                true
-            }
-        };
-        return clang_ok;
-    }
+/// Report the C driver used to link compiled programs.
+///
+/// Its version is informational. The compiler emits an object file, so any
+/// driver that can link one works - a mismatch against the linked LLVM used to
+/// mean IR parse errors and no longer means anything.
+fn report_clang_for_doctor(linker: Option<&str>) -> bool {
+    let Some(linker_cmd) = linker else {
+        println!(
+            "{} No C compiler found to link programs with.",
+            status_marker(false)
+        );
+        print_linker_install_help();
+        return false;
+    };
 
-    println!("{} Clang is not installed.", status_marker(false));
-    print_llvm_install_help();
-    false
+    match extract_clang_major(linker_cmd) {
+        Some(major) => println!(
+            "{} Linker driver: {} (version {}).",
+            status_marker(true),
+            linker_cmd,
+            major
+        ),
+        None => println!("{} Linker driver: {}.", status_marker(true), linker_cmd),
+    }
+    true
 }
 
 // Running a clang binary that was just written and chmod'd can transiently fail
@@ -809,10 +817,16 @@ fn analyze_semantics_or_exit(
     }
 }
 
-fn generate_ir_or_exit(
+/// Run codegen, then write the object file the linker consumes - and, when
+/// `-i` asked for it, the readable `.ll` alongside it.
+///
+/// Only the object is on the critical path. The textual IR used to be, which is
+/// what tied an install to a clang matching this compiler's LLVM major.
+fn generate_object_or_exit(
     codegen: &mut codegen::CodeGenerator,
     nodes: &[ast::AstNode],
-    ir_file: &str,
+    object_file: &str,
+    ir_file: Option<&str>,
 ) {
     if let Err(e) = codegen.generate(nodes) {
         spinner::stop();
@@ -822,9 +836,18 @@ fn generate_ir_or_exit(
         report_internal_compiler_error(&format!("codegen error: {}", e));
         process::exit(1);
     }
-    if let Err(e) = codegen.emit_ir_to_file(ir_file) {
+    // IR first: when the module is invalid, the emitted `.ll` is exactly what is
+    // needed to debug it, and object emission verifies and would bail first.
+    if let Some(ir_file) = ir_file
+        && let Err(e) = codegen.emit_ir_to_file(ir_file)
+    {
         spinner::stop();
         report_internal_compiler_error(&format!("failed to emit IR: {}", e));
+        process::exit(1);
+    }
+    if let Err(e) = codegen.emit_object_to_file(object_file) {
+        spinner::stop();
+        report_internal_compiler_error(&format!("failed to emit object file: {}", e));
         process::exit(1);
     }
 }
@@ -918,15 +941,14 @@ fn report_clang_output_or_exit(
     }
 }
 
-fn remove_ir_if_requested(intermediate: bool, ir_file: &str) {
-    if intermediate {
-        return;
-    }
-
-    Command::new("rm")
-        .arg(ir_file)
-        .status()
-        .expect("Failed to remove intermediate IR file");
+/// Delete the object file once it has been linked. It is a build artifact the
+/// user did not ask for, unlike the `.ll`, which is now only written when `-i`
+/// requested it and so is never cleaned up here.
+///
+/// Best-effort: a failure to remove a temporary file should not fail a
+/// successful compile.
+fn remove_object_file(object_file: &str) {
+    let _ = fs::remove_file(object_file);
 }
 
 fn run_executable_or_exit(exe_file: &Path) {
@@ -1118,11 +1140,18 @@ fn main() {
         .unwrap_or_else(|| file_path.to_string_lossy().into_owned());
     let mut codegen = codegen::CodeGenerator::new(&context, &mut analyzer, &source_name);
 
-    let ir_file = format!(
-        "{}.ll",
-        file_path.to_string_lossy().trim_end_matches(".mux")
+    let stem = file_path
+        .to_string_lossy()
+        .trim_end_matches(".mux")
+        .to_string();
+    let ir_file = format!("{}.ll", stem);
+    let object_file = format!("{}.o", stem);
+    generate_object_or_exit(
+        &mut codegen,
+        &nodes,
+        &object_file,
+        intermediate.then_some(ir_file.as_str()),
     );
-    generate_ir_or_exit(&mut codegen, &nodes, &ir_file);
 
     // build executable
     // Use ./ prefix to ensure we run the local executable, not a system command
@@ -1151,7 +1180,7 @@ fn main() {
 
     let clang_cmd = find_clang_or_exit();
     let mut clang_args = vec![
-        ir_file.clone(),
+        object_file.clone(),
         "-L".to_string(),
         lib_path_str.to_string(),
         format!("-Wl,-rpath,{}", lib_path_str),
@@ -1199,7 +1228,7 @@ fn main() {
     spinner::stop();
     report_clang_output_or_exit(clang_output, do_run, &file_path, &ir_file);
 
-    remove_ir_if_requested(intermediate, &ir_file);
+    remove_object_file(&object_file);
 
     if do_run {
         run_executable_or_exit(&exe_file);
@@ -1518,7 +1547,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn clang_doctor_reports_matching_and_mismatching_majors() {
+    fn linker_doctor_accepts_any_driver_version() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = unique_tmp("fake_clang");
@@ -1545,10 +1574,16 @@ mod tests {
         assert_eq!(extract_clang_major(matching), Some(linked_major));
         assert!(report_clang_for_doctor(Some(matching)));
 
+        // A driver whose version differs from the linked LLVM is fine now: the
+        // compiler emits an object file, so nothing parses textual IR and the
+        // versions need not agree. This used to be a hard failure.
         let mismatching = write_fake_clang("clang-mismatch", linked_major + 1);
-        assert!(!report_clang_for_doctor(Some(
-            mismatching.to_str().unwrap()
-        )));
+        let mismatching = mismatching.to_str().unwrap();
+        assert_eq!(extract_clang_major(mismatching), Some(linked_major + 1));
+        assert!(report_clang_for_doctor(Some(mismatching)));
+
+        // No driver at all is still a failure - something has to link.
+        assert!(!report_clang_for_doctor(None));
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -1551,6 +1551,33 @@ mod tests {
         }
     }
 
+    /// The object file is created exclusively too, not just the directory
+    /// holding it. LLVM emits into memory and the compiler writes the bytes
+    /// itself, so the only filesystem entry involved is one this process
+    /// creates - a file or symlink already at that path is an error rather than
+    /// a write redirected somewhere else.
+    #[cfg(unix)]
+    #[test]
+    fn object_file_creation_refuses_an_existing_symlink() {
+        let base = unique_tmp("obj_squat");
+        std::fs::create_dir_all(&base).unwrap();
+        let victim = base.join("victim");
+        std::fs::write(&victim, b"UNTOUCHED").unwrap();
+
+        let object = base.join("module.o");
+        std::os::unix::fs::symlink(&victim, &object).unwrap();
+
+        let err = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&object)
+            .expect_err("create_new must refuse an existing symlink, not follow it");
+        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(std::fs::read(&victim).unwrap(), b"UNTOUCHED");
+
+        std::fs::remove_dir_all(&base).ok();
+    }
+
     /// The scratch directory must be created exclusively, because a bare
     /// predictable path in a shared temp directory is a symlink-squatting
     /// target: a local process pre-creates it pointing at a file this user can

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -990,7 +990,7 @@ fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
         ));
 
         let mut options = fs::OpenOptions::new();
-        options.write(true).create_new(true);
+        options.read(true).write(true).create_new(true);
         #[cfg(windows)]
         {
             // FILE_FLAG_DELETE_ON_CLOSE: the OS removes the file when the last

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -828,12 +828,14 @@ fn generate_object_or_exit(
     nodes: &[ast::AstNode],
     object_file: &str,
     ir_file: Option<&str>,
+    scratch_dir: &Path,
 ) {
     if let Err(e) = codegen.generate(nodes) {
         spinner::stop();
         // A codegen failure is an internal compiler bug, not a language-level
         // error in the user's program, so it gets the internal-error framing
         // rather than a bare message.
+        remove_scratch_dir(scratch_dir);
         report_internal_compiler_error(&format!("codegen error: {}", e));
         process::exit(1);
     }
@@ -843,11 +845,13 @@ fn generate_object_or_exit(
         && let Err(e) = codegen.emit_ir_to_file(ir_file)
     {
         spinner::stop();
+        remove_scratch_dir(scratch_dir);
         report_internal_compiler_error(&format!("failed to emit IR: {}", e));
         process::exit(1);
     }
     if let Err(e) = codegen.emit_object_to_file(object_file) {
         spinner::stop();
+        remove_scratch_dir(scratch_dir);
         report_internal_compiler_error(&format!("failed to emit object file: {}", e));
         process::exit(1);
     }
@@ -1202,6 +1206,18 @@ fn main() {
         .trim_end_matches(".mux")
         .to_string();
     let ir_file = format!("{}.ll", stem);
+
+    // Resolved before the scratch directory exists and before codegen runs.
+    // Neither depends on codegen, both exit the process on failure, and
+    // `process::exit` skips destructors - so anything created first would be
+    // left behind. Failing before the expensive work is better regardless.
+    let lib_dir = resolve_runtime_lib_dir_or_exit();
+    let lib_path_str = lib_dir
+        .to_str()
+        .expect("library path should be valid Unicode")
+        .to_string();
+    let linker_cmd = find_linker_or_exit();
+
     let scratch_dir = match scratch_object_dir() {
         Ok(dir) => dir,
         Err(e) => {
@@ -1216,6 +1232,7 @@ fn main() {
         &nodes,
         &object_file,
         intermediate.then_some(ir_file.as_str()),
+        &scratch_dir,
     );
 
     // build executable
@@ -1237,13 +1254,6 @@ fn main() {
         parent.join(file_stem)
     };
 
-    let lib_dir = resolve_runtime_lib_dir_or_exit();
-
-    let lib_path_str = lib_dir
-        .to_str()
-        .expect("library path should be valid Unicode");
-
-    let linker_cmd = find_linker_or_exit();
     let mut linker_args = vec![
         object_file.clone(),
         "-L".to_string(),

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -826,16 +826,16 @@ fn analyze_semantics_or_exit(
 fn generate_object_or_exit(
     codegen: &mut codegen::CodeGenerator,
     nodes: &[ast::AstNode],
+    object: &mut fs::File,
     object_file: &str,
     ir_file: Option<&str>,
-    scratch_dir: &Path,
 ) {
     if let Err(e) = codegen.generate(nodes) {
         spinner::stop();
         // A codegen failure is an internal compiler bug, not a language-level
         // error in the user's program, so it gets the internal-error framing
         // rather than a bare message.
-        remove_scratch_dir(scratch_dir);
+        remove_scratch_object(object_file);
         report_internal_compiler_error(&format!("codegen error: {}", e));
         process::exit(1);
     }
@@ -845,13 +845,13 @@ fn generate_object_or_exit(
         && let Err(e) = codegen.emit_ir_to_file(ir_file)
     {
         spinner::stop();
-        remove_scratch_dir(scratch_dir);
+        remove_scratch_object(object_file);
         report_internal_compiler_error(&format!("failed to emit IR: {}", e));
         process::exit(1);
     }
-    if let Err(e) = codegen.emit_object_to_file(object_file) {
+    if let Err(e) = codegen.emit_object(object) {
         spinner::stop();
-        remove_scratch_dir(scratch_dir);
+        remove_scratch_object(object_file);
         report_internal_compiler_error(&format!("failed to emit object file: {}", e));
         process::exit(1);
     }
@@ -946,56 +946,57 @@ fn report_clang_output_or_exit(
     }
 }
 
-/// Name of the object file inside the scratch directory. Shared so cleanup
-/// removes exactly the file emission created.
-const SCRATCH_OBJECT_NAME: &str = "module.o";
-
-/// A private directory to emit the object file into, and the path within it.
+/// An exclusively created path for the object file, plus its open handle.
 ///
-/// Not `<source>.o`: that would overwrite a `foo.o` the user already had beside
-/// `foo.mux` and then delete it during cleanup, losing a file the compiler does
-/// not own.
+/// A file directly in the temp directory, with no directory of our own in
+/// between. Two properties make that safe, and an intermediate component would
+/// lose both:
 ///
-/// Not a bare path in the shared temp directory either. A predictable name that
-/// LLVM opens without exclusive creation is a symlink-squatting target - a local
-/// process can pre-create it pointing at any file this user can write, and the
-/// emitted object lands there instead. So the *directory* is created
-/// exclusively: `create_dir` fails if the path exists at all, including as a
-/// symlink, and mode 0700 keeps anyone else from placing entries inside it
-/// afterwards. The object name within it can then be fixed and boring.
-fn scratch_object_dir() -> Result<PathBuf, String> {
+/// - `create_new` is `O_CREAT|O_EXCL`, so an existing file or symlink here is an
+///   error, never a write redirected through it. Nothing is opened that this
+///   process did not create, and the handle is returned so no path is resolved
+///   again afterwards.
+/// - Symlink traversal applies only to *non-final* path components, and `unlink`
+///   never follows the final one. So cleanup cannot reach outside this path even
+///   if the entry is swapped later: it would remove the replacement link itself,
+///   not whatever it points at.
+///
+/// Not `<source>.o` - that would clobber a `foo.o` the user already had beside
+/// `foo.mux`. The pid and a monotonic counter keep concurrent compiles from
+/// colliding (the test suite runs many at once), and exclusive creation turns
+/// any collision that does occur into a retry rather than an overwrite.
+fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
     use std::sync::atomic::{AtomicU64, Ordering};
     static SEQ: AtomicU64 = AtomicU64::new(0);
 
-    // Distinct candidates rather than secret ones: exclusive creation is what
-    // provides the safety, and the nanosecond clock only avoids self-collision
-    // between concurrent compiles.
+    let name = Path::new(stem)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "mux_module".to_string());
+
     for _ in 0..16 {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos())
             .unwrap_or(0);
         let candidate = env::temp_dir().join(format!(
-            "mux-{}-{}-{}",
+            "mux-{}-{}-{}-{}.o",
+            name,
             process::id(),
             nanos,
             SEQ.fetch_add(1, Ordering::Relaxed)
         ));
 
-        let mut builder = fs::DirBuilder::new();
-        #[cfg(unix)]
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
         {
-            use std::os::unix::fs::DirBuilderExt;
-            builder.mode(0o700);
-        }
-        match builder.create(&candidate) {
-            Ok(()) => return Ok(candidate),
-            // Taken already - by a concurrent compile or by a squatter. Either
-            // way, try a different name rather than writing into it.
+            Ok(file) => return Ok((candidate.to_string_lossy().into_owned(), file)),
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
             Err(e) => {
                 return Err(format!(
-                    "failed to create a temporary directory at {}: {}",
+                    "failed to create a temporary object file at {}: {}",
                     candidate.display(),
                     e
                 ));
@@ -1003,26 +1004,20 @@ fn scratch_object_dir() -> Result<PathBuf, String> {
         }
     }
 
-    Err("could not create a temporary directory for the object file".to_string())
+    Err("could not create a temporary object file".to_string())
 }
 
-/// Remove exactly what was put in the scratch directory, then the directory
-/// itself. The object is a build artifact the user did not ask for, unlike the
-/// `.ll`, which is only written when `-i` requested it and is never cleaned up
-/// here.
+/// Remove the object file once it has been linked. It is a build artifact the
+/// user did not ask for, unlike the `.ll`, which is only written when `-i` asked
+/// for it and is never cleaned up here.
 ///
-/// Deliberately not `remove_dir_all`: that recursively deletes whatever is at
-/// the path, and the path is all this holds - if the directory it names is no
-/// longer the one this process created, a recursive delete would take unrelated
-/// data with it. Removing the single known file and then a non-recursive
-/// `remove_dir` cannot: `remove_dir` refuses a directory containing anything
-/// else, and refuses a symlink outright. Anything unexpected is left alone.
+/// `unlink` does not follow the final path component, so this removes this
+/// path's own entry and never anything it might point at.
 ///
-/// Best-effort throughout: failing to clean up a temporary file must not fail an
-/// otherwise successful compile.
-fn remove_scratch_dir(dir: &Path) {
-    let _ = fs::remove_file(dir.join(SCRATCH_OBJECT_NAME));
-    let _ = fs::remove_dir(dir);
+/// Best-effort: failing to remove a temporary file must not fail an otherwise
+/// successful compile.
+fn remove_scratch_object(object_file: &str) {
+    let _ = fs::remove_file(object_file);
 }
 
 fn run_executable_or_exit(exe_file: &Path) {
@@ -1231,25 +1226,23 @@ fn main() {
         .to_string();
     let linker_cmd = find_linker_or_exit();
 
-    let scratch_dir = match scratch_object_dir() {
-        Ok(dir) => dir,
+    let (object_file, mut object) = match create_scratch_object(&stem) {
+        Ok(pair) => pair,
         Err(e) => {
             spinner::stop();
             report_internal_compiler_error(&e);
             process::exit(1);
         }
     };
-    let object_file = scratch_dir
-        .join(SCRATCH_OBJECT_NAME)
-        .to_string_lossy()
-        .into_owned();
     generate_object_or_exit(
         &mut codegen,
         &nodes,
+        &mut object,
         &object_file,
         intermediate.then_some(ir_file.as_str()),
-        &scratch_dir,
     );
+    // Close the handle so the linker reads a fully flushed file.
+    drop(object);
 
     // build executable
     // Use ./ prefix to ensure we run the local executable, not a system command
@@ -1320,7 +1313,7 @@ fn main() {
     // Before interpreting the result: a spawn failure or a nonzero linker exit
     // ends the process inside the call below, so cleaning up afterwards would
     // leak the scratch object on exactly the paths that fail.
-    remove_scratch_dir(&scratch_dir);
+    remove_scratch_object(&object_file);
     report_clang_output_or_exit(linker_output, do_run, &file_path, &ir_file);
 
     if do_run {
@@ -1334,7 +1327,7 @@ mod tests {
         REQUIRED_LLVM_MAJOR, clang_failure_detail, clang_version_output, compiling_file,
         dir_holding_runtime_lib, extract_clang_major, find_runtime_lib_in_dir, format_panic_detail,
         internal_compiler_error_report, llvm_config_candidates, pick_llvm_for_dev,
-        print_doctor_verdict, print_version_banner, relativize_to_cwd, remove_scratch_dir,
+        print_doctor_verdict, print_version_banner, relativize_to_cwd, remove_scratch_object,
         report_clang_for_doctor, report_runtime_for_doctor, runtime_lib_dir_is_static_only,
         set_compiling_file, status_marker, validate_llvm_for_doctor,
     };
@@ -1567,63 +1560,24 @@ mod tests {
         }
     }
 
-    /// Cleanup must remove only what emission created. The scratch path is all
-    /// the compiler holds, so if the directory it names is no longer the one
-    /// this process made, a recursive delete would take unrelated data with it.
-    /// This pins that a directory holding anything else survives.
-    #[test]
-    fn scratch_cleanup_leaves_a_replaced_directory_alone() {
-        let base = unique_tmp("scratch_replace");
-        std::fs::create_dir_all(&base).unwrap();
-
-        // Stand in for a directory that is not the one emission created: it has
-        // unrelated contents and no object file.
-        let replacement = base.join("scratch");
-        std::fs::create_dir_all(&replacement).unwrap();
-        std::fs::write(replacement.join("someone_elses_data"), b"KEEP").unwrap();
-
-        remove_scratch_dir(&replacement);
-
-        assert!(
-            replacement.is_dir(),
-            "a directory holding unrelated files must survive cleanup"
-        );
-        assert_eq!(
-            std::fs::read(replacement.join("someone_elses_data")).unwrap(),
-            b"KEEP"
-        );
-
-        // The directory this process did create - one object file, nothing else -
-        // is removed completely.
-        let ours = base.join("ours");
-        std::fs::create_dir_all(&ours).unwrap();
-        std::fs::write(ours.join("module.o"), b"obj").unwrap();
-        remove_scratch_dir(&ours);
-        assert!(!ours.exists(), "our own scratch directory should be gone");
-
-        std::fs::remove_dir_all(&base).ok();
-    }
-
-    /// The object file is created exclusively too, not just the directory
-    /// holding it. LLVM emits into memory and the compiler writes the bytes
-    /// itself, so the only filesystem entry involved is one this process
-    /// creates - a file or symlink already at that path is an error rather than
-    /// a write redirected somewhere else.
+    /// Exclusive creation is what keeps the object off a path this process did
+    /// not make: an existing file or symlink there must be an error, never a
+    /// write redirected through it.
     #[cfg(unix)]
     #[test]
-    fn object_file_creation_refuses_an_existing_symlink() {
-        let base = unique_tmp("obj_squat");
+    fn scratch_object_creation_refuses_an_existing_entry() {
+        let base = unique_tmp("obj_excl");
         std::fs::create_dir_all(&base).unwrap();
+
         let victim = base.join("victim");
         std::fs::write(&victim, b"UNTOUCHED").unwrap();
-
-        let object = base.join("module.o");
-        std::os::unix::fs::symlink(&victim, &object).unwrap();
+        let squatted = base.join("scratch.o");
+        std::os::unix::fs::symlink(&victim, &squatted).unwrap();
 
         let err = std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(&object)
+            .open(&squatted)
             .expect_err("create_new must refuse an existing symlink, not follow it");
         assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
         assert_eq!(std::fs::read(&victim).unwrap(), b"UNTOUCHED");
@@ -1631,35 +1585,34 @@ mod tests {
         std::fs::remove_dir_all(&base).ok();
     }
 
-    /// The scratch directory must be created exclusively, because a bare
-    /// predictable path in a shared temp directory is a symlink-squatting
-    /// target: a local process pre-creates it pointing at a file this user can
-    /// write, and the object LLVM emits lands there instead. `create_dir` is
-    /// what prevents that - this pins that it refuses an existing symlink
-    /// rather than following it.
+    /// Cleanup must not reach outside the path it was given. `unlink` does not
+    /// follow the final component, so a swapped entry loses the replacement link
+    /// itself and never what it points at - which is why the object lives
+    /// directly in the temp directory with no directory of ours in between: an
+    /// intermediate component *would* be traversed.
     #[cfg(unix)]
     #[test]
-    fn scratch_dir_creation_refuses_an_existing_symlink() {
-        let base = unique_tmp("scratch_squat");
+    fn scratch_object_cleanup_does_not_follow_a_replacement_symlink() {
+        let base = unique_tmp("obj_cleanup");
         std::fs::create_dir_all(&base).unwrap();
-        let target = base.join("attacker_target");
-        std::fs::create_dir_all(&target).unwrap();
 
-        let squatted = base.join("scratch");
-        std::os::unix::fs::symlink(&target, &squatted).unwrap();
+        let bystander = base.join("someone_elses.o");
+        std::fs::write(&bystander, b"KEEP").unwrap();
 
-        let err = std::fs::DirBuilder::new()
-            .create(&squatted)
-            .expect_err("creating over an existing symlink must fail, not follow it");
-        assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
+        let object = base.join("scratch.o");
+        std::os::unix::fs::symlink(&bystander, &object).unwrap();
 
-        // Nothing was written through the symlink.
-        assert_eq!(std::fs::read_dir(&target).unwrap().count(), 0);
+        remove_scratch_object(object.to_str().unwrap());
 
-        // A fresh name still succeeds, which is what the retry loop relies on.
-        let fresh = base.join("scratch-2");
-        std::fs::DirBuilder::new().create(&fresh).unwrap();
-        assert!(fresh.is_dir());
+        assert!(
+            !object.exists() && std::fs::symlink_metadata(&object).is_err(),
+            "the replacement link itself should be gone"
+        );
+        assert_eq!(
+            std::fs::read(&bystander).unwrap(),
+            b"KEEP",
+            "the link target must survive cleanup"
+        );
 
         std::fs::remove_dir_all(&base).ok();
     }


### PR DESCRIPTION
Removes the exact-clang-version requirement from every install. No new issue - this came out of the packaging discussion, where the least-friction option turned out to be a compiler change rather than distro packages.

## Why users need `clang-22` today

`main.rs` wrote a `.ll` and passed **that** to clang, so clang was doing two jobs: parsing LLVM IR text, and linking. Textual IR is not stable across LLVM versions, which is why the clang major has to match the LLVM this compiler links - `find_clang_command` searches for `clang-{linked_major}`, and `mux doctor` fails a mismatch with "this will cause IR parse errors."

That is the single biggest source of install friction. It is why `setup.md` has to point users at apt.llvm.org, and it is what Homebrew/AUR packaging was being considered to paper over.

## It was self-imposed

The compiler already links LLVM, so it can ask LLVM for an object file directly. It now does, via `TargetMachine::write_to_file`, and clang receives the object instead of the IR.

**Verified empirically** - a program compiles and runs with gcc as the driver:

```
$ CC=gcc mux run hello.mux
hello
```

gcc 16.1.1 cannot parse the IR text this replaces, so that command was impossible before.

## What changed

- **Linker detection** accepts `cc` and `gcc` alongside clang. The doctor now reports the driver's version as information; a mismatch is no longer a failure, because nothing parses IR any more.
- **The module carries a triple and data layout.** Nothing set them before - that is what clang meant by `overriding the module target triple`. Emitting directly, a mismatch would be wrong ABI decisions rather than a warning, so the module is stamped from the target machine.
- **PIC**, since distributions default to position-independent executables.
- **`-i` still writes the `.ll`**, and writes it *before* object emission, so an invalid module still leaves behind the file needed to debug it. Without `-i` no IR is written at all, and the object is deleted after linking.

## Verification

Full suite green, including `executable_integration` which compiles and runs all 113 test programs. `scripts/leak-check.sh` reports `all programs clean`. `mux doctor` output checked by hand.

## Deliberately not in this PR

User-facing docs still state the clang-22 requirement. That is correct - they describe the *released* compiler, per the "docs follow the release" rule in the release process. They change when this ships.

## What this unblocks

The remaining rungs, each independently useful:

1. Bundle a linker - since LLVM is already statically linked, lld can be embedded rather than shipped as a separate binary.
2. Bundle libc startup files, the last thing a native link needs from the system.

After (1), `curl | sh` needs nothing from the user on any machine with a working `cc`, which makes per-distro packaging optional polish rather than a workaround.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/muxlang/codesmith/mux-compiler/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787960638&installation_model_id=429545&pr_number=318&repository=muxlang%2Fmux-compiler&return_to=https%3A%2F%2Fgithub.com%2Fmuxlang%2Fmux-compiler%2Fpull%2F318&signature=17be034d4374193b05a115a1f65b91a23a06d2b8fda195377a0b164764d0e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->