### PR TITLE
Make the published install work on clean machines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,14 +71,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            runner_name: linux-ubuntu-latest-x86_64
+          # The PUBLISHED Linux build is the oldest supported runner, because a
+          # binary linked against a newer glibc will not start on an older one.
+          # Built on ubuntu-latest, `mux-linux-x86_64.tar.gz` required
+          # GLIBC_2.38/2.39 and so refused to run on Debian 12 stable (2.36),
+          # Ubuntu 22.04 LTS, RHEL 9 and Amazon Linux 2023 - while this build,
+          # which does run there, was produced and then thrown away.
+          - os: ubuntu-22.04
+            runner_name: linux-ubuntu-22.04-x86_64
             target: linux-x86_64
             archive_ext: tar.gz
             publish: true
-          - os: ubuntu-22.04
-            runner_name: linux-ubuntu-22.04-x86_64
-            target: linux-x86_64-ubuntu22
+          # Kept as a sanity build against a current toolchain, not shipped.
+          - os: ubuntu-latest
+            runner_name: linux-ubuntu-latest-x86_64
+            target: linux-x86_64-ubuntu-latest
             archive_ext: tar.gz
             publish: false
           - os: macos-15-intel

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,8 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+# POSIX sh, not bash: the documented one-liner is `curl ... | sh`, and on
+# Debian and Ubuntu /bin/sh is dash. As a bash script this died on line 2 with
+# "Illegal option -o pipefail" before doing anything at all.
+set -eu
 
 REPO="muxlang/mux-compiler"
 INSTALL_DIR_DEFAULT="${HOME}/.local/bin"
@@ -10,7 +13,7 @@ BASE_URL="${MUX_RELEASE_BASE_URL:-https://github.com/${REPO}/releases/latest/dow
 # awk program that extracts the first whitespace-separated field (the checksum).
 AWK_FIRST_FIELD='{print $1}'
 
-if [[ "${1:-}" == "--help" ]]; then
+if [ "${1:-}" = "--help" ]; then
   echo "Mux installer"
   echo
   echo "Environment variables:"
@@ -22,7 +25,8 @@ if [[ "${1:-}" == "--help" ]]; then
 fi
 
 detect_target() {
-  local os arch
+  # No `local`: it is not POSIX (shellcheck SC3043). Both assignments here are
+  # inside a command substitution anyway, so nothing leaks to the caller.
   os="$(uname -s)"
   arch="$(uname -m)"
 
@@ -49,7 +53,6 @@ detect_target() {
 }
 
 require_cmd() {
-  local cmd
   cmd="$1"
 
   if ! command -v "$cmd" >/dev/null 2>&1; then
@@ -80,14 +83,14 @@ curl -fsSL "$CHECKSUM_URL" -o "$tmp_dir/$ARCHIVE.sha256"
 if command -v sha256sum >/dev/null 2>&1; then
   expected="$(awk "$AWK_FIRST_FIELD" "$tmp_dir/$ARCHIVE.sha256")"
   actual="$(sha256sum "$tmp_dir/$ARCHIVE" | awk "$AWK_FIRST_FIELD")"
-  if [[ "$expected" != "$actual" ]]; then
+  if [ "$expected" != "$actual" ]; then
     echo "Checksum verification failed"
     exit 1
   fi
 elif command -v shasum >/dev/null 2>&1; then
   expected="$(awk "$AWK_FIRST_FIELD" "$tmp_dir/$ARCHIVE.sha256")"
   actual="$(shasum -a 256 "$tmp_dir/$ARCHIVE" | awk "$AWK_FIRST_FIELD")"
-  if [[ "$expected" != "$actual" ]]; then
+  if [ "$expected" != "$actual" ]; then
     echo "Checksum verification failed"
     exit 1
   fi
@@ -101,7 +104,7 @@ tar -xzf "$tmp_dir/$ARCHIVE" -C "$tmp_dir"
 
 bundle_root="$tmp_dir/mux-${TARGET}"
 bin_path="$bundle_root/bin/mux"
-if [[ ! -f "$bin_path" ]]; then
+if [ ! -f "$bin_path" ]; then
   echo "Could not find mux binary in archive"
   exit 1
 fi
@@ -109,16 +112,19 @@ fi
 cp "$bin_path" "$INSTALL_DIR/mux"
 chmod +x "$INSTALL_DIR/mux"
 
-if [[ -d "$bundle_root/lib" ]]; then
+if [ -d "$bundle_root/lib" ]; then
   cp -f "$bundle_root/lib"/* "$LIB_DIR/" 2>/dev/null || true
 fi
 
 echo "Installed mux to $INSTALL_DIR/mux"
 echo "Installed runtime libraries to $LIB_DIR"
-if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
-  echo "Add this to your shell profile:"
-  echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
-fi
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    echo "Add this to your shell profile:"
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    ;;
+esac
 
 # Downloading the archive is not the same as being able to compile: the
 # compiler shells out to a matching clang to link every program. `mux doctor`


### PR DESCRIPTION
Two separate bugs, both found by running the documented install in a bare Debian 12 container. Neither is visible to any existing job: `installer_scripts` only *parses* the scripts, and `packaged_artifact` stages the bin/lib layout itself rather than installing a published release.

## 1. The documented one-liner did not run at all on Debian or Ubuntu

`curl ... | sh` executes with `/bin/sh`, which is dash there. `install.sh` was a bash script and died on line 2, before doing anything:

```
/tmp/install.sh: 2: set: Illegal option -o pipefail
```

That is the install command on both the README and the website, so it was broken for the largest Linux audience.

Converted to POSIX sh: `set -eu`, `[` instead of `[[`, a `case` for the PATH check, no `local`. Verified by piping it to dash in a container - it now downloads, verifies the checksum, extracts and installs.

**Note on why CI missed it, since it matters for what to do about it:** `sh -n` would not have caught this - `set -o pipefail` parses fine and fails at runtime. Nor would shellcheck have, because the shebang said `bash` and as a bash script it was correct; the bug was the mismatch between the script's dialect and the documented invocation. Now that the shebang says `#!/bin/sh`, shellcheck checks it as POSIX and flags bashisms, so **the existing `installer_scripts` job guards this class from here on with no new workflow.** It immediately flagged `local` (SC3043), which this PR removes.

## 2. The published Linux binary required a glibc too new to run

```
mux: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
mux: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

Only the `ubuntu-latest` build was published, so `mux-linux-x86_64.tar.gz` needed GLIBC_2.38/2.39 and refused to start on **Debian 12 stable (2.36), Ubuntu 22.04 LTS, RHEL 9, Amazon Linux 2023** - failing before it could print anything useful.

The `ubuntu-22.04` build, which runs fine on all of those, was already being produced every release and then discarded with `publish: false`.

Swapped: the older runner now produces the published artifact, and `ubuntu-latest` stays as an unshipped sanity build against a current toolchain. Both jobs already pass, so this ships something that was being built anyway.

## Verification

Bare `debian:bookworm-slim`, gcc only, no clang, no LLVM, no Rust:

- Before: installer aborted on line 2.
- After: installs cleanly through dash, reaching `mux doctor`.
- The binary then still fails on glibc, which is bug 2 - only fixable at the next release, since it is the *published artifact* that is wrong.

Also confirmed the released binary statically links LLVM (only `libc`, `libstdc++`, `libm`, `libgcc_s`), so users never need LLVM installed to run the compiler. That part was already right.

## Relationship to other work

Independent of #318 and based on `main`, so it can merge in either order. Together they mean a clean machine needs only a C compiler; #319 tracks removing even that.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/muxlang/codesmith/mux-compiler/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787968925&installation_model_id=429545&pr_number=321&repository=muxlang%2Fmux-compiler&return_to=https%3A%2F%2Fgithub.com%2Fmuxlang%2Fmux-compiler%2Fpull%2F321&signature=441869ab49813b2012e49ea4336b99c8ae7abb06ac6dbd8befc9b6f0f215d7e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->