### PR TITLE
Run CI on workflow and all script changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,12 +27,15 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'clippy.toml'
-              - 'scripts/run-checks.sh'
-              - 'scripts/dev-cargo.sh'
-              - 'scripts/valgrind-checks.sh'
-              - 'scripts/bench-report.py'
+              # All of scripts/, not an enumeration: the installers, leak-check
+              # and the integration helpers are all exercised by jobs here, and
+              # a list drifts out of date as jobs are added.
+              - 'scripts/**'
               - 'test_scripts/**'
               - 'infra/**'
+              # A workflow-only change would otherwise skip every job here,
+              # including the one being changed.
+              - '.github/workflows/**'
 
   rust_checks:
     name: Rust Checks


### PR DESCRIPTION
Re-applies a fix that never reached main: I pushed it to #317's branch after that PR had already merged, so it sat on a closed branch.

## The gap

The `rust` path filter enumerates four scripts and omits `.github/workflows` entirely, so:

- A PR touching only `scripts/install.sh` or `scripts/leak-check.sh` **skips every Rust job** - including `installer_scripts`, whose entire purpose is checking those two files.
- A PR touching only a workflow skips the job it is changing.

This is not hypothetical. On #321, which fixes `scripts/install.sh` and `.github/workflows/release.yml`, every gating job reported SKIPPED - `Installer Scripts` included. The claim in that PR that "the existing `installer_scripts` job guards this class from here on" is only true once this lands.

## The fix

`scripts/**` instead of an enumeration that drifts as jobs are added, plus `.github/workflows/**`.

Same shape as the bug this whole line of work started from: a check that does not run where it matters. The v0.6.0 install shipped broken because no job exercised the packaged layout; these filters meant the jobs guarding that could themselves be skipped by exactly the changes most likely to break them.

Companion: muxlang/mux-runtime has the identical gap, fixed the same way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/muxlang/codesmith/mux-compiler/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787970012&installation_model_id=429545&pr_number=322&repository=muxlang%2Fmux-compiler&return_to=https%3A%2F%2Fgithub.com%2Fmuxlang%2Fmux-compiler%2Fpull%2F322&signature=a2a5052ffb24b5be5d36d847dbf98d3cb112dbbd08a53b4cdd89997f0c36c7da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->