### PR TITLE
fix: report the linker's own error, not just its exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offer their own `clear()` as a regular method, and the dsa classes do.
 
 ### Fixed
+- **A failed link now reports the linker's own error, not just its exit code**:
+  the internal-error report was built from clang's stderr alone. `ld` and `lld`
+  write diagnostics there, but MSVC's `link.exe` writes them to stdout, so on
+  Windows the entire report was `linking failed: clang-22: error: linker command
+  failed with exit code 1104` - the `LNK1104: cannot open file '...'` line naming
+  the actual problem was discarded. Both streams are reported now. Found when the
+  packaged-artifact smoke test was first run on Windows, where a link failure was
+  undiagnosable from CI logs.
 - **Same-named globals in different modules no longer collide**: module-level
   globals were emitted and keyed by their bare name, so two imported modules
   each declaring e.g. `const int SHARED` shared one slot and both resolved to

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -893,14 +893,26 @@ fn find_linker_or_exit() -> String {
     }
 }
 
-/// Build the internal-error detail line for a failed link from clang's stderr.
+/// Build the internal-error detail line for a failed link from clang's output.
+///
+/// Both streams are reported because the linker's own diagnostics do not land on
+/// the same one everywhere: `ld` and `lld` write to stderr, while MSVC's
+/// `link.exe` writes to stdout. Reading stderr alone on Windows reduces the whole
+/// report to "linker command failed with exit code 1104" and drops the `LNK1104:
+/// cannot open file '...'` line that says what is actually wrong.
+///
 /// Trailing whitespace is trimmed so the report does not end with a blank line;
 /// pure so the wording is unit-tested without spawning clang.
-fn clang_failure_detail(stderr: &[u8]) -> String {
-    format!(
-        "linking failed: {}",
-        String::from_utf8_lossy(stderr).trim_end()
-    )
+fn clang_failure_detail(stdout: &[u8], stderr: &[u8]) -> String {
+    let mut parts = Vec::new();
+    for stream in [stderr, stdout] {
+        let text = String::from_utf8_lossy(stream);
+        let trimmed = text.trim_end();
+        if !trimmed.is_empty() {
+            parts.push(trimmed.to_string());
+        }
+    }
+    format!("linking failed: {}", parts.join("\n"))
 }
 
 /// What the driver should do about clang's result. Decided without side effects
@@ -923,7 +935,9 @@ fn classify_clang_output(
 ) -> ClangOutcome {
     match clang_output {
         Ok(output) if output.status.success() => ClangOutcome::Linked,
-        Ok(output) => ClangOutcome::LinkFailed(clang_failure_detail(&output.stderr)),
+        Ok(output) => {
+            ClangOutcome::LinkFailed(clang_failure_detail(&output.stdout, &output.stderr))
+        }
         Err(e) => ClangOutcome::SpawnFailed(format!(
             "Failed to run clang: {}. IR file generated at: {}",
             e, ir_file
@@ -1411,10 +1425,28 @@ mod tests {
     #[test]
     fn clang_failure_detail_labels_and_trims_stderr() {
         assert_eq!(
-            clang_failure_detail(b"ld: undefined symbol: pow\n\n"),
+            clang_failure_detail(b"", b"ld: undefined symbol: pow\n\n"),
             "linking failed: ld: undefined symbol: pow"
         );
-        assert_eq!(clang_failure_detail(b""), "linking failed: ");
+        assert_eq!(clang_failure_detail(b"", b""), "linking failed: ");
+    }
+
+    #[test]
+    fn clang_failure_detail_includes_stdout_for_msvc_link() {
+        // MSVC's link.exe writes LNK diagnostics to stdout, so a stderr-only
+        // report would say nothing but the exit code.
+        let detail = clang_failure_detail(
+            b"LINK : fatal error LNK1104: cannot open file 'zstd.lib'\n",
+            b"clang-22: error: linker command failed with exit code 1104\n",
+        );
+        assert!(
+            detail.contains("LNK1104: cannot open file 'zstd.lib'"),
+            "{detail}"
+        );
+        assert!(
+            detail.contains("linker command failed with exit code 1104"),
+            "{detail}"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## The bug

The internal-error report for a failed link was built from clang's **stderr
alone**:

```rust
fn clang_failure_detail(stderr: &[u8]) -> String {
    format!("linking failed: {}", String::from_utf8_lossy(stderr).trim_end())
}
```

`ld` and `lld` write their diagnostics to stderr, so this worked on Linux and
macOS. **MSVC's `link.exe` writes them to stdout.** On Windows the whole report
was therefore:

```
error: internal compiler error
  linking failed: clang-22: error: linker command failed with exit code 1104
```

The `LNK1104: cannot open file '...'` line - the part that says what is actually
missing - was captured by `Command::output()` and discarded.

## Why it matters

A link failure that names nothing is close to undiagnosable. The report even
suggests re-running with `RUST_BACKTRACE=1`, which produces the identical single
line, because the detail was never read in the first place.

## The fix

Report both streams, stderr first so output is unchanged everywhere the linker
already used it.

## How it was found

Bringing up the packaged-artifact smoke test on Windows in
muxlang/mux-compiler#327 - the first time a compiled Mux program has ever been
linked on Windows in CI. It fails, and the log could not say why. That
investigation is blocked on this.

## Tests

- Existing `clang_failure_detail_labels_and_trims_stderr` updated for the new
  signature; behaviour on stderr-only input is unchanged, including the empty
  case.
- New `clang_failure_detail_includes_stdout_for_msvc_link` asserts a realistic
  MSVC pair keeps both the `LNK1104` line and the exit-code line.

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and the
full test suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
