### PR TITLE
fix: make compiling a program work on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offer their own `clear()` as a regular method, and the dsa classes do.
 
 ### Fixed
+- **Compiling a program on Windows now links**: the temporary object file was
+  created with `FILE_FLAG_DELETE_ON_CLOSE` and its handle held open across the
+  link. While such a handle is open, Windows fails any open that does not itself
+  pass `FILE_SHARE_DELETE` - and `link.exe` does not - so every compile ended in
+  `LNK1104: cannot open file` naming an object that existed and was readable.
+  The share mode on the creating handle cannot grant that; only the opener's can.
+  Windows now keeps the object named, closes the handle before linking, and
+  removes it afterwards, including on the codegen-failure path. The unix path is
+  unchanged: it still unlinks at creation and passes the descriptor as the
+  linker's stdin, which has no Windows equivalent.
+- **Windows no longer receives ELF-only linker options**: `-Wl,-rpath`,
+  `-Wl,--disable-new-dtags` and `-Wl,--gc-sections` were passed on every
+  platform. MSVC's linker answered each with `LNK4044: unrecognized option` and
+  ignored it. Windows resolves a DLL from the executable's own directory, and
+  MSVC dead-strips by default, so the flags are simply not emitted there.
 - **A failed link now reports the linker's own error, not just its exit code**:
   the internal-error report was built from clang's stderr alone. `ld` and `lld`
   write diagnostics there, but MSVC's `link.exe` writes them to stdout, so on

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -966,6 +966,22 @@ fn report_clang_output_or_exit(
     }
 }
 
+/// Remove the named scratch object, warning rather than failing if it will not
+/// go.
+///
+/// Only the platforms that keep a name need this; unix released it at creation.
+/// By the time this runs the link has already happened, so a stuck temp file is
+/// untidy rather than fatal and must not change the exit status - but it should
+/// not be silent either. On Windows an antivirus scanner can hold a transient
+/// lock on a freshly written object, and a discarded error there means these
+/// accumulate in the temp directory with nothing ever saying so.
+#[cfg(not(unix))]
+fn remove_scratch_object(path: &str) {
+    if let Err(e) = fs::remove_file(path) {
+        eprintln!("warning: could not remove the temporary object file {path}: {e}");
+    }
+}
+
 /// How the linker refers to an object it reads from inherited stdin. `/dev/fd` is
 /// standard on Linux and the BSDs, macOS included, and `/dev/stdin` is the
 /// descriptor-0 entry within it.
@@ -1289,9 +1305,9 @@ fn main() {
         // elsewhere the name is still on disk and has to be removed too, or a
         // codegen failure leaves the object behind for good.
         drop(object);
-        #[cfg(not(unix))]
-        let _ = fs::remove_file(&object_file);
         spinner::stop();
+        #[cfg(not(unix))]
+        remove_scratch_object(&object_file);
         report_internal_compiler_error(&e);
         process::exit(1);
     }
@@ -1391,14 +1407,16 @@ fn main() {
 
     let linker_output = linker.output();
 
+    spinner::stop();
+
     // The name outlives the handle now, so it has to be removed explicitly, and
     // before report_clang_output_or_exit - that exits the process on a link
     // failure, which would otherwise leak the object into the temp directory on
-    // exactly the runs that produce one.
+    // exactly the runs that produce one. After the spinner stops, so a warning
+    // cannot interleave with it.
     #[cfg(not(unix))]
-    let _ = fs::remove_file(&object_file);
+    remove_scratch_object(&object_file);
 
-    spinner::stop();
     report_clang_output_or_exit(linker_output, do_run, &file_path, &ir_file);
 
     if do_run {

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -991,6 +991,12 @@ const LINKER_STDIN_OBJECT: &str = "/dev/stdin";
 /// `foo.mux`. The pid and a monotonic counter keep concurrent compiles from
 /// colliding (the test suite runs many at once), and exclusive creation turns
 /// any collision that does occur into a retry rather than an overwrite.
+///
+/// The two platforms then diverge, because only one of them can hand the linker
+/// a descriptor. Unix unlinks immediately and passes the open descriptor as the
+/// child's stdin, so no name exists to race against. Windows has no equivalent:
+/// the linker must open the object by path, so the file keeps its name, the
+/// handle is closed before the link, and the caller removes it afterwards.
 fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
     use std::sync::atomic::{AtomicU64, Ordering};
     static SEQ: AtomicU64 = AtomicU64::new(0);
@@ -1015,17 +1021,13 @@ fn create_scratch_object(stem: &str) -> Result<(String, fs::File), String> {
 
         let mut options = fs::OpenOptions::new();
         options.read(true).write(true).create_new(true);
-        #[cfg(windows)]
-        {
-            // FILE_FLAG_DELETE_ON_CLOSE: the OS removes the file when the last
-            // handle closes, so Windows needs no delete-by-path at all - and so
-            // has no pathname that could be replaced between check and unlink.
-            // std's default share mode includes FILE_SHARE_DELETE, so the linker
-            // can still read it while this handle is open.
-            use std::os::windows::fs::OpenOptionsExt;
-            const FILE_FLAG_DELETE_ON_CLOSE: u32 = 0x0400_0000;
-            options.custom_flags(FILE_FLAG_DELETE_ON_CLOSE);
-        }
+        // Deliberately NOT FILE_FLAG_DELETE_ON_CLOSE on Windows. That flag looks
+        // ideal - the OS reclaims the file with no delete-by-path at all - but it
+        // changes how OTHER processes may open the file: while such a handle is
+        // open, any opener that does not itself pass FILE_SHARE_DELETE gets a
+        // sharing violation. link.exe does not, so it failed with
+        // "LNK1104: cannot open file" on an object that existed and was readable.
+        // The share mode on THIS handle cannot grant that; only the opener's can.
         match options.open(&candidate) {
             Ok(file) => {
                 #[cfg(unix)]
@@ -1282,10 +1284,13 @@ fn main() {
         &mut object,
         intermediate.then_some(ir_file.as_str()),
     ) {
-        // Release the handle before exiting. `process::exit` skips destructors,
-        // so on Windows - where closing the handle is what deletes the file -
-        // exiting while holding it would leave the object behind for good.
+        // `process::exit` skips destructors, so both of these are explicit.
+        // Unix released the name at creation and needs only the handle dropped;
+        // elsewhere the name is still on disk and has to be removed too, or a
+        // codegen failure leaves the object behind for good.
         drop(object);
+        #[cfg(not(unix))]
+        let _ = fs::remove_file(&object_file);
         spinner::stop();
         report_internal_compiler_error(&e);
         process::exit(1);
@@ -1314,20 +1319,33 @@ fn main() {
         object_file.clone(),
         "-L".to_string(),
         lib_path_str.to_string(),
-        format!("-Wl,-rpath,{}", lib_path_str),
         "-ffunction-sections".to_string(),
         "-fdata-sections".to_string(),
     ];
 
-    #[cfg(not(target_os = "macos"))]
-    linker_args.push("-Wl,--disable-new-dtags".to_string());
+    // rpath and the dtags flag are ELF concepts. MSVC's linker answers both with
+    // "LNK4044: unrecognized option" and ignores them; Windows resolves a DLL
+    // from the executable's own directory, which is where a packaged install
+    // puts the runtime.
+    #[cfg(not(target_os = "windows"))]
+    {
+        linker_args.push(format!("-Wl,-rpath,{}", lib_path_str));
+        #[cfg(not(target_os = "macos"))]
+        linker_args.push("-Wl,--disable-new-dtags".to_string());
+    }
 
-    let gc_sections_flag = if cfg!(target_os = "macos") {
-        "-Wl,-dead_strip".to_string()
-    } else {
-        "-Wl,--gc-sections".to_string()
-    };
-    linker_args.push(gc_sections_flag);
+    // Dead-stripping is spelled differently per linker, and MSVC's does it by
+    // default at the optimisation levels that matter, so Windows passes nothing
+    // rather than an option that would only be warned about.
+    #[cfg(not(target_os = "windows"))]
+    {
+        let gc_sections_flag = if cfg!(target_os = "macos") {
+            "-Wl,-dead_strip".to_string()
+        } else {
+            "-Wl,--gc-sections".to_string()
+        };
+        linker_args.push(gc_sections_flag);
+    }
     linker_args.push("-lmux_runtime".to_string());
 
     // A static-only libmux_runtime.a carries no NEEDED entries, so its undefined
@@ -1363,12 +1381,22 @@ fn main() {
         // file is released as soon as linking finishes - no cleanup path at all.
         linker.stdin(Stdio::from(object));
     }
-    let linker_output = linker.output();
 
-    // Unix moved the handle into the child's stdin above; elsewhere release it
-    // here, before a link failure can exit the process while it is still held.
+    // Elsewhere the linker opens the object by PATH, so this handle must be
+    // closed BEFORE the link, not after: an open writer blocks link.exe from
+    // opening it and surfaces as "LNK1104: cannot open file". Closing here also
+    // flushes the object to disk, which the linker is about to read.
     #[cfg(not(unix))]
     drop(object);
+
+    let linker_output = linker.output();
+
+    // The name outlives the handle now, so it has to be removed explicitly, and
+    // before report_clang_output_or_exit - that exits the process on a link
+    // failure, which would otherwise leak the object into the temp directory on
+    // exactly the runs that produce one.
+    #[cfg(not(unix))]
+    let _ = fs::remove_file(&object_file);
 
     spinner::stop();
     report_clang_output_or_exit(linker_output, do_run, &file_path, &ir_file);


### PR DESCRIPTION
Two bugs on the Windows-only half of the object-file linking added in #318. Both
were found the first time CI ever ran a compiled Mux program on Windows
(muxlang/mux-compiler#327), and #328 is what made them readable.

## 1. `DELETE_ON_CLOSE` made the object unopenable by the linker

The temp object was created with `FILE_FLAG_DELETE_ON_CLOSE` and its handle held
open across the link. The reasoning in the comment was:

> std's default share mode includes FILE_SHARE_DELETE, so the linker can still
> read it while this handle is open.

That has the direction backwards. The flag constrains **other** openers: while
such a handle is open, any process opening the file must itself pass
`FILE_SHARE_DELETE` or get a sharing violation. `link.exe` does not. So every
compile on Windows ended in:

```
LINK : fatal error LNK1104: cannot open file '...\mux-smoke-7460-...-0.o'
```

naming an object that existed and was perfectly readable. The share mode on the
creating handle cannot grant what the opener has to ask for itself.

**Fix:** Windows keeps the object named, closes the handle **before** the link
(which also flushes it), and removes it by path afterwards - including on the
codegen-failure path, which previously relied on the handle drop to delete it.

The unix path is untouched. It still unlinks at creation and hands the descriptor
to the linker as stdin, so no name exists to race against. That has no Windows
equivalent, which is the reason the platforms diverge here at all - the trade is
a named file in the per-user temp directory for a link that works.

## 2. ELF-only linker options were passed on every platform

`-Wl,-rpath`, `-Wl,--disable-new-dtags` and `-Wl,--gc-sections` went everywhere.
MSVC's linker answered each with `LNK4044: unrecognized option` and ignored it:

```
LINK : warning LNK4044: unrecognized option '/rpath'; ignored
LINK : warning LNK4044: unrecognized option '/-disable-new-dtags'; ignored
LINK : warning LNK4044: unrecognized option '/-gc-sections'; ignored
```

Windows resolves a DLL from the executable's own directory - which is where a
packaged install puts the runtime - and MSVC dead-strips by default. Nothing is
emitted there rather than an option that can only be warned about.

## Verification

`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`, and the
full test suite including `executable_integration` pass locally.

The Windows branches **cannot be compiled on a Linux host** - cross-checking
fails in llvm-sys/cc-rs looking for `lib.exe`. They were type-checked by
temporarily inverting the `unix` cfgs so the `not(unix)` code compiles here,
which passes; the file was then restored and the diff confirmed to contain only
the intended changes. The Windows CI leg added in #327 is the real verification,
and this is exactly the class of bug it exists to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
