### PR TITLE
fix: link Windows against the import library, not a stray DLL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offer their own `clear()` as a regular method, and the dsa classes do.
 
 ### Fixed
+- **Windows links against the import library, not a stray DLL**: runtime
+  resolution accepted any directory containing `mux_runtime.dll` as the one to
+  link against. A packaged install must keep that DLL beside `mux.exe` for the
+  loader to find it, so `bin/` always won over the `lib/` holding
+  `mux_runtime.lib` - and a bare DLL is not a linker input on Windows, so every
+  compile failed with `LNK1181: cannot open input file 'mux_runtime.lib'`. A
+  dynamic library now only counts as linkable where it actually is, which is
+  everywhere except Windows.
 - **Compiling a program on Windows now links**: the temporary object file was
   created with `FILE_FLAG_DELETE_ON_CLOSE` and its handle held open across the
   link. While such a handle is open, Windows fails any open that does not itself

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -256,6 +256,19 @@ fn find_runtime_lib_in_dir(dir: &Path) -> Option<PathBuf> {
         return Some(static_lib);
     }
 
+    // A bare DLL is not a linker input on Windows: you link against the import
+    // library and the DLL is only loaded at run time. Accepting one here picks a
+    // directory the linker cannot use, and since a real install must put the DLL
+    // beside the executable for the loader to find it, `bin/` would always win
+    // over the `lib/` holding the import library - failing every compile with
+    // "LNK1181: cannot open input file 'mux_runtime.lib'".
+    //
+    // Elsewhere a shared object is a perfectly good link input, so it still
+    // counts.
+    if cfg!(target_family = "windows") {
+        return None;
+    }
+
     let dynamic_lib = runtime_dynamic_lib_path(dir);
     if dynamic_lib.exists() {
         return Some(dynamic_lib);
@@ -1647,13 +1660,45 @@ mod tests {
         assert_eq!(find_runtime_lib_in_dir(&static_dir), Some(static_path));
         std::fs::remove_dir_all(&static_dir).ok();
 
-        // Dynamic library is found when only it is present.
+        // A dynamic library alone: a link input everywhere except Windows, where
+        // only the import library is linkable and a bare DLL must not make the
+        // directory look usable.
         let dyn_dir = unique_tmp("rtlib_dyn");
         std::fs::create_dir_all(&dyn_dir).unwrap();
         let dyn_path = dyn_dir.join(dynamic_lib_name());
         std::fs::write(&dyn_path, b"x").unwrap();
-        assert_eq!(find_runtime_lib_in_dir(&dyn_dir), Some(dyn_path));
+        if cfg!(target_family = "windows") {
+            assert!(find_runtime_lib_in_dir(&dyn_dir).is_none());
+        } else {
+            assert_eq!(find_runtime_lib_in_dir(&dyn_dir), Some(dyn_path));
+        }
         std::fs::remove_dir_all(&dyn_dir).ok();
+    }
+
+    /// A packaged Windows install keeps the DLL beside the executable so the
+    /// loader finds it, and the import library under `lib/`. Resolution must
+    /// therefore skip `bin/` and choose `lib/` - picking `bin/` passes the
+    /// linker a directory holding nothing it can link, which is
+    /// "LNK1181: cannot open input file 'mux_runtime.lib'".
+    #[test]
+    fn a_dll_beside_the_binary_does_not_shadow_the_import_library() {
+        let root = unique_tmp("rtlib_install");
+        let bin = root.join("bin");
+        let lib = root.join("lib");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(&lib).unwrap();
+        std::fs::write(bin.join(dynamic_lib_name()), b"x").unwrap();
+        let import_lib = lib.join(static_lib_name());
+        std::fs::write(&import_lib, b"x").unwrap();
+
+        if cfg!(target_family = "windows") {
+            assert!(
+                dir_holding_runtime_lib(&bin).is_none(),
+                "a bare DLL in bin/ must not claim to provide a linkable runtime"
+            );
+        }
+        assert_eq!(dir_holding_runtime_lib(&lib), Some(lib.clone()));
+        std::fs::remove_dir_all(&root).ok();
     }
 
     /// The compiler links whatever directory this reports, so it must name the
@@ -1667,7 +1712,14 @@ mod tests {
         assert!(dir_holding_runtime_lib(&empty_dir).is_none());
         std::fs::remove_dir_all(&empty_dir).ok();
 
-        for name in [static_lib_name(), dynamic_lib_name()] {
+        // Only the names that are actually linkable on this platform. A bare
+        // DLL is not one on Windows, so it deliberately reports nothing there.
+        let linkable: &[&str] = if cfg!(target_family = "windows") {
+            &[static_lib_name()]
+        } else {
+            &[static_lib_name(), dynamic_lib_name()]
+        };
+        for name in linkable {
             let dir = unique_tmp("rtdir_present");
             std::fs::create_dir_all(&dir).unwrap();
             std::fs::write(dir.join(name), b"x").unwrap();


### PR DESCRIPTION
Third Windows bug from the same investigation, and the one #329 uncovered by
getting far enough to hit it. The error moved from `LNK1104` (the object file) to
`LNK1181` (the runtime library), and the `LNK4044` warnings are gone.

## The bug

`find_runtime_lib_in_dir` accepted a **dynamic** library as proof that a
directory provides the runtime:

```rust
let dynamic_lib = runtime_dynamic_lib_path(dir);   // mux_runtime.dll on Windows
if dynamic_lib.exists() {
    return Some(dynamic_lib);
}
```

True on unix, where a shared object is a perfectly good link input. **False on
Windows**: you link against the import library, and the DLL is only loaded at run
time.

It bites because of where a real install must put things. The Windows loader
resolves a DLL from the executable's own directory, so a packaged install keeps
`mux_runtime.dll` in `bin/` - and `runtime_lib_near_executable` checks the
executable's directory **first**:

```
dist/bin/   mux.exe, mux_runtime.dll      <- chosen: has a "runtime library"
dist/lib/   mux_runtime.lib               <- skipped: never reached
```

So the compiler passed the linker a directory containing nothing linkable:

```
LINK : fatal error LNK1181: cannot open input file 'mux_runtime.lib'
```

This is not a CI artifact. `release.yml` packages the DLL into `bin/` for exactly
the same loader reason, so every published Windows install would fail the same
way.

## The fix

A dynamic library counts as linkable only where it genuinely is - everywhere
except Windows. There, resolution needs the import library, which is what `lib/`
holds.

## Tests

Two existing tests asserted that a dynamic-only directory resolves. That is now
platform-dependent, so both are split rather than loosened.

Added `a_dll_beside_the_binary_does_not_shadow_the_import_library`, which builds
the real install shape - DLL in `bin/`, import library in `lib/` - and asserts
`bin/` is skipped and `lib/` chosen.

## Verification

`fmt`, `clippy -D warnings`, and the full suite pass natively.

Because the interesting branch is compiled out on Linux, the resolution tests
were also run with the `target_family = "windows"` branches forced live. That is
how the stale assertion in `dir_holding_runtime_lib_reports_the_directory_itself`
was found - it would otherwise have failed on Windows CI. Both suites pass under
both semantics now.

Windows CI in muxlang/mux-compiler#327 remains the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
