### PR TITLE
fix: a DLL beside the runtime archive is not a dynamic link on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reported as `LNK4098: defaultlib 'MSVCRT' conflicts` and then failing on the
   CRT symbols the runtime's vendored C code imports (`__imp_realloc`,
   `__imp_strcspn`). The compiler now asks clang for the DLL runtime.
+- **A DLL beside the runtime archive no longer suppresses Windows system
+  libraries**: `runtime_lib_dir_is_static_only` treated the presence of
+  `mux_runtime.dll` as proof the link was dynamic, exactly as a `.so` would mean
+  on unix. On Windows the link target is whichever `.lib` is resolved, and cargo
+  names the staticlib `mux_runtime.lib` against the cdylib's
+  `mux_runtime.dll.lib` - so `-lmux_runtime` is always the static archive, and
+  the DLL is only there because the loader needs it. Reading it as dynamic
+  skipped the native system libraries and failed every Windows compile with
+  `LNK2019`, even after those libraries were added.
 - **Windows links the system libraries a static runtime needs**: the explicit
   native-dependency list was skipped on Windows, on the grounds that "the import
   lib records its own deps". `mux_runtime.lib` is a *static* library, not an

--- a/mux-compiler/src/main.rs
+++ b/mux-compiler/src/main.rs
@@ -286,6 +286,20 @@ fn runtime_lib_dir_is_static_only(dir: &Path) -> bool {
     if !runtime_static_lib_path(dir).exists() {
         return false;
     }
+
+    // On Windows this is a question about which .lib the linker picks, not about
+    // whether a DLL is present. mux-runtime builds both a staticlib and a
+    // cdylib, and cargo names them `mux_runtime.lib` and `mux_runtime.dll.lib`
+    // respectively - so `-lmux_runtime` always resolves the STATIC archive. A
+    // DLL sitting beside it does not make the link dynamic; it is there because
+    // the loader needs it, and a packaged install ships it for that reason.
+    //
+    // Reading the DLL as "dynamic" here suppressed the native system libraries
+    // below and failed every Windows compile with LNK2019 on symbols they own.
+    if cfg!(target_family = "windows") {
+        return true;
+    }
+
     let dynamic_lib = runtime_dynamic_lib_path(dir);
     !dynamic_lib.exists()
 }
@@ -1709,6 +1723,31 @@ mod tests {
                 .iter()
                 .any(|c| c == &format!("llvm-config-{}", REQUIRED_LLVM_MAJOR))
         );
+    }
+
+    /// A packaged Windows install ships the DLL beside the import-less static
+    /// archive, because the loader needs it. That must not read as a dynamic
+    /// link: `-lmux_runtime` still resolves mux_runtime.lib, so the runtime's
+    /// native dependencies still have to be linked explicitly.
+    #[test]
+    fn a_dll_in_the_lib_dir_does_not_make_the_link_dynamic() {
+        let dir = unique_tmp("staticonly_both");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(static_lib_name()), b"x").unwrap();
+        std::fs::write(dir.join(dynamic_lib_name()), b"x").unwrap();
+
+        if cfg!(target_family = "windows") {
+            assert!(
+                runtime_lib_dir_is_static_only(&dir),
+                "a DLL beside the static archive is a loader artifact, not a dynamic link"
+            );
+        } else {
+            assert!(
+                !runtime_lib_dir_is_static_only(&dir),
+                "a shared object beside the archive genuinely is a dynamic link input"
+            );
+        }
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// Every platform's list, checked on any host. The Windows entries are the


### PR DESCRIPTION
Sixth Windows bug in this chain, and the reason the fifth appeared to do nothing:
the system libraries added in #331 were computed correctly and then **never
appended**, so the link failed with the identical `LNK2019` set.

## The gate was asking the wrong question

```rust
if runtime_lib_dir_is_static_only(lib_dir) {
    for native_lib in native_runtime_deps(env::consts::OS) { ... }
}
```

and that helper treated a DLL's presence as proof the link was dynamic:

```rust
let dynamic_lib = runtime_dynamic_lib_path(dir);   // mux_runtime.dll
!dynamic_lib.exists()
```

Correct on unix, where a `.so` beside the archive genuinely is a dynamic link
input. Wrong on Windows, where the link target is whichever `.lib` resolves.

mux-runtime is `crate-type = ["staticlib", "cdylib", "rlib"]`, and cargo names
those `mux_runtime.lib` (the 348 MB static archive) and `mux_runtime.dll.lib`
(the import library). So **`-lmux_runtime` always resolves the static archive**,
and the DLL is present only because the loader needs it.

The staged layout made this obvious once the sizes were visible:

```
dist/lib/  mux_runtime.dll   14 MB    <- loader artifact
           mux_runtime.lib  348 MB    <- what actually gets linked
```

`release.yml` packages the DLL into `lib/` for the same loader reason, so this
affected real installs, not just CI.

## Same error, one function along

This is the identical conceptual mistake fixed in #330, in the neighbouring
function: a Windows DLL is not a unix shared object, and neither *resolution*
nor *link-mode detection* can treat it as one. Worth noting because the pattern
is what to look for if a seventh turns up.

## Tests

`a_dll_in_the_lib_dir_does_not_make_the_link_dynamic` builds the real layout -
static archive plus DLL - and asserts Windows reports static-only while unix
does not. Passes natively and with the `target_family` cfgs forced to the
Windows branches.

`fmt`, `clippy -D warnings` and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
