### PR TITLE
ci: pin every action to a SHA, and add Dependabot so that is not a freeze

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -65,7 +65,7 @@ runs:
 
     - name: Setup Miniconda (Windows)
       if: runner.os == 'Windows'
-      uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167
+      uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0
       with:
         auto-update-conda: true
         use-mamba: true
@@ -79,7 +79,7 @@ runs:
 
     - name: Setup MSVC developer command prompt (Windows)
       if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
 
     - name: Unshadow the MSVC linker (Windows)
       if: runner.os == 'Windows'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Every action is pinned to a commit SHA, which is what stops a moved tag from
+# reaching our tokens. The cost is that a pin never updates on its own, so
+# pinning without this file just freezes the versions instead - including past a
+# security fix. Dependabot reads the `# vX.Y.Z` comment beside each SHA and
+# updates both together.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # Patch and minor only, in one PR. Majors are deliberately excluded:
+      # several actions here are multiple majors behind, so a single ungated
+      # group would open one all-or-nothing PR crossing every one of them at
+      # once. That PR breaks CI everywhere, cannot be partially merged, and ends
+      # up sitting open forever - which freezes the pins just as effectively as
+      # having no Dependabot at all. Majors then arrive one action at a time,
+      # each reviewable on its own.
+      actions-routine:
+        patterns:
+          - "*"
+        update-types:
+          - patch
+          - minor
+    ignore:
+      # Pinned to an untagged commit on master that is NEWER than the repo's
+      # only tag (v1). Left to Dependabot the single "update" available is a
+      # downgrade, which would drop the cross-device copy fix. Move by hand.
+      - dependency-name: dtolnay/rust-toolchain
+    commit-message:
+      prefix: "ci"
+    # `chore` replaces Dependabot's default `dependencies` label rather than
+    # adding to it. Deliberate: `chore` is the label this org actually triages
+    # on, and it exists in every repo, whereas `dependencies` does not.
+    labels:
+      - chore
+
+  # Dependabot scans .github/workflows and a ROOT action.yml, but does not
+  # recurse into .github/actions/*/action.yml. Without this second entry the two
+  # pins inside the composite action would never be updated - the exact freeze
+  # this file exists to prevent.
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup-llvm
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+    labels:
+      - chore

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,16 +45,16 @@ jobs:
       CC: clang-22
       CXX: clang++-22
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
         with:
           toolchain: 1.93.1
           components: llvm-tools-preview
       - name: Install LLVM 22
         run: ./scripts/ci/install-llvm.sh
       - name: Cache Cargo registry and build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -82,7 +82,7 @@ jobs:
         # only then fail on the upload.
         run: printf 'suffix=%s\n' "${GITHUB_REF_NAME//[^A-Za-z0-9._-]/-}" >> "$GITHUB_OUTPUT"
       - name: Upload benchmark report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-report-${{ steps.label.outputs.suffix }}
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,8 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |
@@ -65,9 +65,9 @@ jobs:
       contents: read
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
         with:
           toolchain: 1.93.1
           components: rustfmt
@@ -88,7 +88,7 @@ jobs:
       CC: clang-22
       CXX: clang++-22
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       # No mux-runtime checkout: cargo builds it from the commit Cargo.lock
       # pins, into target/, which is the library every program here links. That
       # is what a release ships, so testing anything else would test a
@@ -96,14 +96,14 @@ jobs:
       # caught by mux-runtime's own CI, which builds this repo's `main` against
       # its source.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
         with:
           toolchain: 1.93.1
           components: rustfmt, clippy, llvm-tools-preview
       - name: Install LLVM 22
         run: ./scripts/ci/install-llvm.sh
       - name: Cache Cargo registry and build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -143,7 +143,7 @@ jobs:
         # executed in the spawned compiler is captured.
         run: cargo llvm-cov -p mux-lang --all-features --lcov --output-path lcov.info
       - name: Upload coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-lcov
           path: lcov.info
@@ -160,7 +160,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Parse and analyze install.ps1
         shell: pwsh
@@ -233,9 +233,9 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
         with:
           toolchain: 1.93.1
       - name: Setup LLVM 22
@@ -295,7 +295,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Docker info
         run: docker compose version
       - name: Service-backed checks
@@ -317,11 +317,11 @@ jobs:
       CC: clang-22
       CXX: clang++-22
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       # Programs link the runtime cargo builds into target/ from the commit
       # Cargo.lock pins - the same library a release ships.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
         with:
           toolchain: 1.93.1
           components: llvm-tools-preview
@@ -330,7 +330,7 @@ jobs:
       - name: Install Valgrind
         run: sudo apt-get install -y valgrind
       - name: Cache Cargo registry and build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -347,7 +347,7 @@ jobs:
       - name: Upload valgrind log for PR comment
         # Raw log only; the trusted pr-comment workflow escapes and renders it.
         if: ${{ always() && github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr-comment-valgrind
           path: valgrind.log
@@ -379,21 +379,21 @@ jobs:
       # so it is the one runtime the compiler cannot produce on its own.
       MUX_RUNTIME_LEAK_FEATURES: core,json,csv,net,sql,sync,rc-leak-check
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: muxlang/mux-runtime
           ref: main
           path: mux-runtime
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
         with:
           toolchain: 1.93.1
           components: llvm-tools-preview
       - name: Install LLVM 22
         run: ./scripts/ci/install-llvm.sh
       - name: Cache Cargo registry and build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             ~/.cargo/registry
@@ -434,16 +434,16 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: Download coverage report
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         continue-on-error: true
         with:
           name: coverage-lcov
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       # The scan above waits for analysis (sonar.qualitygate.wait), so the

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,7 +11,7 @@ jobs:
   ensure-triage-label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const labelName = 'needs triage';

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Download report artifacts from the triggering run
         if: ${{ steps.pr.outputs.number != '' }}
         continue-on-error: true # a path-skipped Build uploads no artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     # No LLVM env here: setup-llvm exports every one of these, and two sources
     # for the same variable is how they drift apart.
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -35,7 +35,7 @@ jobs:
           fi
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
         with:
           toolchain: 1.93.1
           components: rustfmt, clippy
@@ -99,10 +99,10 @@ jobs:
             publish: true
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
         with:
           toolchain: 1.93.1
 
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload build artifacts
         if: matrix.publish
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mux-${{ matrix.target }}
           path: |
@@ -287,10 +287,10 @@ jobs:
           apt-get install -y --no-install-recommends \
             ca-certificates curl gcc libc6-dev tar gzip git python3
 
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Download the artifact built by this run
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           # This leg's platform only. Downloading the whole set would pull ~200MB
           # to serve one file.
@@ -370,10 +370,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Download artifacts
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
 
@@ -424,7 +424,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Publish to GitHub Releases
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           body: ${{ steps.changelog.outputs.body }}
           files: |


### PR DESCRIPTION
Step 8 of the CI/CD plan. One of seven near-identical PRs.

## Pinning

**18 of 28 action references were mutable tags.** A tag is repointable by whoever
controls the action repo - the mechanism behind the tj-actions compromise - and
these are public repos where `SONAR_TOKEN` appears in 14 workflow steps with
`GITHUB_TOKEN` write scope in `pr-comment.yml`.

Every reference is now a full commit SHA with the exact version beside it. Also
reconciled: `actions/checkout` was pinned at **three different SHAs** across the
org, and `actions/download-artifact` at two.

## A version change this PR is making, said out loud

The comments are exact (`# v4.4.0`) rather than major-only, and that is not
cosmetic - **major-only is what hid a version change in this very diff.**

The three checkout SHAs were `11d5960` (v4.4.0), `11bd7190` (v4.2.2) and
`34e11487` (v4.3.1). Normalising to one moves `release.yml` and the website-api
canary **forward to v4.4.0**, which upstream flags `[BREAKING]` for adding
`allow-unsafe-pr-checkout` and changing `pull_request_target` defaults.

Nothing here is affected - verified across all seven repos: no workflow uses
`pull_request_target`, the two `workflow_run` workflows contain no checkout step
at all, and no checkout passes an untrusted PR head `ref:`. But it is a real
version change inside a commit that claims to be pinning, so it is visible in
the diff rather than buried behind `# v4`.

## Dependabot, and why the obvious config is wrong

Pinning without automation does not secure the versions, it **freezes** them -
including past a security fix. Three things this config does that the naive
version does not:

**Majors are excluded from the group.** Ten of these actions are between one and
five majors behind (checkout v4 -> v7, download-artifact v4 -> v8,
github-script v7 -> v9, ...). A single ungated `patterns: ["*"]` group opens one
all-or-nothing PR crossing every major at once: it breaks CI in every repo
simultaneously, cannot be partially merged, and sits open forever - freezing the
pins exactly as effectively as having no Dependabot. Patch and minor are grouped;
majors arrive one action at a time.

**mux-compiler gets a second entry for `.github/actions/setup-llvm`.** Dependabot
scans `.github/workflows` plus a **root** `action.yml`; it does not recurse into
`.github/actions/*/action.yml`. Without that entry the two pins inside the
composite action would never move - the precise freeze this file exists to
prevent.

**`dtolnay/rust-toolchain` is ignored.** It is pinned to an untagged commit on
`master` that is *newer* than the repo's only tag (`v1`), so the one "update"
available is a **downgrade** that drops the cross-device copy fix.

## Follow-ups this surfaced

- `mux-runtime/.github/workflows/ci.yml` uses `image: postgres:16` and
  `image: mysql:8` - mutable tags, same class of hole, not addressed here.
- `sha_pinning_required` (GitHub's native enforcement) is safe to enable once
  this merges: everything is a 40-char SHA or a local `./` ref.
- Only the `github-actions` ecosystem is configured. cargo, npm and pip remain
  unmanaged; the plan scoped this step to actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
