### PR TITLE
Add actionlint + shellcheck gate on workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,21 @@ jobs:
               # including the one being changed.
               - '.github/workflows/**'
 
+  lint_workflows:
+    # actionlint plus its built-in shellcheck integration (active once
+    # shellcheck is on PATH, which it is on this image) - context #29's
+    # lint-the-pipeline-itself ask. Ungated: a workflow-only change is exactly
+    # what this exists to catch, and it is cheap enough not to need a filter.
+    name: Lint Workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - name: actionlint + shellcheck
+        run: ./scripts/ci/lint-workflows.sh
+
   format:
     # Formatting only. Clippy deliberately stays with rust_checks: it compiles
     # the crate, so it needs the LLVM install and the build cache and could

--- a/scripts/ci/lint-workflows.sh
+++ b/scripts/ci/lint-workflows.sh
@@ -31,7 +31,11 @@ workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 
 archive="actionlint_${actionlint_version}_linux_amd64.tar.gz"
-curl -sSfL -o "${workdir}/${archive}" \
+# --proto "=https": -L follows redirects, and without pinning the protocol a
+# redirect could silently downgrade the transfer to plain HTTP (CWE-757). The
+# sha256 check below still catches a tampered file, but this stops the
+# downgrade itself rather than only detecting its result.
+curl -sSfL --proto "=https" -o "${workdir}/${archive}" \
   "https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/${archive}"
 echo "${actionlint_sha256}  ${workdir}/${archive}" | sha256sum -c -
 tar -xzf "${workdir}/${archive}" -C "${workdir}" actionlint

--- a/scripts/ci/lint-workflows.sh
+++ b/scripts/ci/lint-workflows.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Lint .github/workflows/**.yml with actionlint. actionlint also shellchecks
+# every inline `run:` bash block itself, as long as a `shellcheck` binary is on
+# PATH - there is nothing else to wire up for that half of context #29's ask.
+#
+# actionlint has no severity flag, so shellcheck's style/info findings are
+# excluded here to match the threshold build.yml's own standalone shellcheck
+# check already uses (`--severity=warning` on install.sh); warning and error
+# still fail the job.
+set -euo pipefail
+
+actionlint_version="1.7.12"
+actionlint_sha256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+
+os="$(uname -s)"
+arch="$(uname -m)"
+if [[ "$os" != "Linux" || "$arch" != "x86_64" ]]; then
+  echo "lint-workflows.sh only runs on Linux x86_64 (got ${os}/${arch})" >&2
+  exit 1
+fi
+
+# Those findings on the run: blocks are what make this gate more than a YAML
+# syntax check; a silently-disabled integration would report a clean run
+# having checked nothing.
+if ! command -v shellcheck >/dev/null; then
+  echo "shellcheck not found on PATH; actionlint would silently skip its shellcheck integration" >&2
+  exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+
+archive="actionlint_${actionlint_version}_linux_amd64.tar.gz"
+curl -sSfL -o "${workdir}/${archive}" \
+  "https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/${archive}"
+echo "${actionlint_sha256}  ${workdir}/${archive}" | sha256sum -c -
+tar -xzf "${workdir}/${archive}" -C "${workdir}" actionlint
+
+# style/info findings are excluded (see the file header); actionlint's own
+# rules (runner-label, syntax-check, ...) never match this pattern, so they
+# always fail the job regardless of level.
+"${workdir}/actionlint" -color -ignore 'SC[0-9]+:(style|info):'

--- a/scripts/ci/lint-workflows.sh
+++ b/scripts/ci/lint-workflows.sh
@@ -35,7 +35,11 @@ archive="actionlint_${actionlint_version}_linux_amd64.tar.gz"
 # redirect could silently downgrade the transfer to plain HTTP (CWE-757). The
 # sha256 check below still catches a tampered file, but this stops the
 # downgrade itself rather than only detecting its result.
-curl -sSfL --proto "=https" -o "${workdir}/${archive}" \
+# --retry 5 --retry-all-errors: a single attempt under `set -e` fails the
+# whole job on any transient DNS/network/GitHub Releases hiccup before any
+# workflow gets linted. Matches the 5-attempt retry already used for the
+# SonarCloud issue-count check in these same workflows.
+curl -sSfL --proto "=https" --retry 5 --retry-all-errors -o "${workdir}/${archive}" \
   "https://github.com/rhysd/actionlint/releases/download/v${actionlint_version}/${archive}"
 echo "${actionlint_sha256}  ${workdir}/${archive}" | sha256sum -c -
 tar -xzf "${workdir}/${archive}" -C "${workdir}" actionlint


### PR DESCRIPTION
## Summary

- Step 9 of the CI/CD rework plan (context #29's "actionlint + shellcheck on `.github/workflows/**`" row): a new **Lint Workflows** job in `build.yml` runs `actionlint`, whose built-in shellcheck integration covers every inline `run:` bash block once `shellcheck` is on `PATH` (preinstalled on `ubuntu-latest`) - so there is nothing separate to wire up for the shellcheck half.
- `scripts/ci/lint-workflows.sh` downloads actionlint pinned by version and verified by sha256 (no new marketplace action, matching the pinned-download pattern already used for LLVM/cargo-insta), and ignores shellcheck's style/info findings to match the `--severity=warning` threshold the existing "Installer Scripts" job already applies to `install.sh`. Warning/error findings, and all of actionlint's own rules, still fail the job.
- Pinning to a current actionlint release (**v1.7.12**) rather than whatever an older snapshot happens to carry matters concretely here: the `macos-15-intel` runner label used in `release.yml` is unrecognized by v1.7.7 but is recognized by v1.7.12, so this passes clean with no `.github/actionlint.yaml` allowlist needed. (Correction from an earlier revision of this description: v1.7.12 is not where that label support was *added* - it lands in an earlier 1.7.x release - it is simply new enough to carry it.)
- The job is deliberately ungated (no `needs`/`if`) - it's a ~5s check and a workflow-only change is exactly what it exists to catch.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the modified workflow - valid YAML
- [x] Ran the pinned actionlint v1.7.12 + shellcheck locally against this repo's `.github/workflows/**` with the same ignore pattern the script uses - clean (0 findings)
- [x] `shellcheck --severity=warning scripts/ci/lint-workflows.sh` - clean
- [x] Ran `scripts/ci/lint-workflows.sh` itself end-to-end locally (fresh download + checksum verify + lint) - passes
- [x] Reviewed by a subagent standing in for Greptile (credits exhausted org-wide): verified the sha256 pin against the real release asset, traced the `-ignore` regex against actionlint's shellcheck-message format, ran the script end-to-end including a simulated 404 to confirm `set -e` aborts correctly, and confirmed the checkout SHA/permissions/timeout match this file's existing conventions. No functional defects found.
- [ ] CI green on this PR (the job lints itself)