### PR TITLE
Cache Cargo build artifacts, not just the registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,16 +201,26 @@ jobs:
           components: clippy
       - name: Setup LLVM 22
         uses: ./.github/actions/setup-llvm
-      - name: Cache Cargo registry and build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache Cargo registry and build artifacts
+        # Was actions/cache over ~/.cargo/{registry,git,bin} only. Despite the
+        # step name, target/ was never cached, so every job below did a cold
+        # full compile of the LLVM/inkwell dependency tree on every run.
+        #
+        # Adding target/ to the old config would not have worked: all four jobs
+        # shared one key, so whichever finished first saved its target/ and the
+        # other three restored artifacts built under a different profile
+        # (clippy runs --all-targets --all-features, coverage runs
+        # instrumented). rust-cache keys per job automatically - job id plus
+        # rustc version plus Cargo.lock - which is what makes a shared cache
+        # correct here rather than merely large.
+        #
+        # save-if restricts writes to main: four jobs each saving a multi-GB
+        # target/ on every PR run would churn through the 10GB repo cache limit
+        # and evict the entries this exists to provide. PRs restore from main's
+        # cache, which is the state they branch from anyway.
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build
         # mux-runtime is a dependency, and cargo builds only a dependency's
         # rlib - not the staticlib compiled Mux programs link against.
@@ -240,16 +250,26 @@ jobs:
           components: rustfmt, llvm-tools-preview
       - name: Setup LLVM 22
         uses: ./.github/actions/setup-llvm
-      - name: Cache Cargo registry and build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache Cargo registry and build artifacts
+        # Was actions/cache over ~/.cargo/{registry,git,bin} only. Despite the
+        # step name, target/ was never cached, so every job below did a cold
+        # full compile of the LLVM/inkwell dependency tree on every run.
+        #
+        # Adding target/ to the old config would not have worked: all four jobs
+        # shared one key, so whichever finished first saved its target/ and the
+        # other three restored artifacts built under a different profile
+        # (clippy runs --all-targets --all-features, coverage runs
+        # instrumented). rust-cache keys per job automatically - job id plus
+        # rustc version plus Cargo.lock - which is what makes a shared cache
+        # correct here rather than merely large.
+        #
+        # save-if restricts writes to main: four jobs each saving a multi-GB
+        # target/ on every PR run would churn through the 10GB repo cache limit
+        # and evict the entries this exists to provide. PRs restore from main's
+        # cache, which is the state they branch from anyway.
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Rust checks
         run: ./scripts/run-checks.sh
       - name: Install cargo-insta
@@ -461,16 +481,26 @@ jobs:
         uses: ./.github/actions/setup-llvm
       - name: Install Valgrind
         run: sudo apt-get install -y valgrind
-      - name: Cache Cargo registry and build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache Cargo registry and build artifacts
+        # Was actions/cache over ~/.cargo/{registry,git,bin} only. Despite the
+        # step name, target/ was never cached, so every job below did a cold
+        # full compile of the LLVM/inkwell dependency tree on every run.
+        #
+        # Adding target/ to the old config would not have worked: all four jobs
+        # shared one key, so whichever finished first saved its target/ and the
+        # other three restored artifacts built under a different profile
+        # (clippy runs --all-targets --all-features, coverage runs
+        # instrumented). rust-cache keys per job automatically - job id plus
+        # rustc version plus Cargo.lock - which is what makes a shared cache
+        # correct here rather than merely large.
+        #
+        # save-if restricts writes to main: four jobs each saving a multi-GB
+        # target/ on every PR run would churn through the 10GB repo cache limit
+        # and evict the entries this exists to provide. PRs restore from main's
+        # cache, which is the state they branch from anyway.
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Valgrind checks
         id: run
         run: |
@@ -519,16 +549,26 @@ jobs:
           components: llvm-tools-preview
       - name: Setup LLVM 22
         uses: ./.github/actions/setup-llvm
-      - name: Cache Cargo registry and build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      - name: Cache Cargo registry and build artifacts
+        # Was actions/cache over ~/.cargo/{registry,git,bin} only. Despite the
+        # step name, target/ was never cached, so every job below did a cold
+        # full compile of the LLVM/inkwell dependency tree on every run.
+        #
+        # Adding target/ to the old config would not have worked: all four jobs
+        # shared one key, so whichever finished first saved its target/ and the
+        # other three restored artifacts built under a different profile
+        # (clippy runs --all-targets --all-features, coverage runs
+        # instrumented). rust-cache keys per job automatically - job id plus
+        # rustc version plus Cargo.lock - which is what makes a shared cache
+        # correct here rather than merely large.
+        #
+        # save-if restricts writes to main: four jobs each saving a multi-GB
+        # target/ on every PR run would churn through the 10GB repo cache limit
+        # and evict the entries this exists to provide. PRs restore from main's
+        # cache, which is the state they branch from anyway.
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build the rc-leak-check runtime
         run: |
           set -euo pipefail


### PR DESCRIPTION
## What

Replaces the four `actions/cache` steps in `build.yml` with `Swatinem/rust-cache`, pinned to v2.9.1 (`c1937114`, the commit the annotated tag dereferences to).

## Why

Every cache step was named **"Cache Cargo registry and build"** but its `path:` listed only:

```yaml
~/.cargo/registry
~/.cargo/git
~/.cargo/bin
```

`target/` was never cached. So `clippy`, `rust_checks`, `valgrind` and `rc_leak_check` each did a **cold full compile** of the LLVM/inkwell dependency tree on every run. mux-runtime's equivalent jobs have cached `target/` all along - this brings the compiler in line with its sibling.

## Why not just add `target/` to the existing config

All four jobs share one key (`${{ runner.os }}-cargo-${{ hashFiles(...) }}`). Whichever finished first would save its `target/`, and the other three would restore artifacts built under a **different profile** - clippy runs `--all-targets --all-features`, coverage runs instrumented. That is cache thrash, not a cache.

`rust-cache` keys per job automatically (job id + rustc version + `Cargo.lock`) and prunes intermediate artifacts before saving, so the four caches stay distinct and bounded.

> Worth noting for a follow-up: **mux-runtime has this exact latent bug today** - three of its jobs share one key *and* include `target`.

## `save-if`

Writes are restricted to `main`. Four jobs each saving a multi-GB `target/` on every PR run would churn through the 10GB per-repo cache limit and evict the entries this exists to provide. PRs restore from `main`, which is the state they branch from anyway.

The tradeoff: a PR that changes `Cargo.lock` gets a miss and will not save, so it recompiles on each push. `rust-cache`'s restore-keys still give a partial hit.

## Deliberately not in scope

- `ab_benchmark_gate`'s release registry cache and pinned base-SHA baseline cache - different profile, different keying problem.
- `packaged_artifact` has **no cargo cache at all**, which is a large share of the Windows critical path. Bigger win, separate change.

## Verification

`cache-bin` defaults on, so the `~/.cargo/bin` behaviour that `cargo-insta` and `cargo-llvm-cov` relied on is preserved.

The real proof is the timings on this PR versus `main`. Note that the **first** run here will be a cold miss (no `main` cache exists under the new keys yet) - the saving shows up once this lands on `main` and subsequent PRs restore from it.