### PR TITLE
Integration Checks: run the service suite only, not the whole unit suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kept `list` and `set` out of the interface. `Collection` is now a read-oriented
   view (`len`, `is_empty`, `to_list`, `contains`); implementations may still
   offer their own `clear()` as a regular method, and the dsa classes do.
+- **Integration Checks no longer re-runs the unit test suite.**
+  `run-checks.sh --with-service-tests` is now `--service-tests-only` and runs
+  the `service_integration` suite alone. The old flag ran the full unit suite
+  inside the compose container first, duplicating what the parallel Rust Checks
+  job already ran on the host and adding roughly 180s to every PR and push.
 
 ### Fixed
 - **Windows links one CRT instead of two**: clang's driver passes

--- a/scripts/integration-checks.sh
+++ b/scripts/integration-checks.sh
@@ -16,4 +16,4 @@ trap cleanup EXIT
 "$repo_root/scripts/integration-up.sh"
 
 docker compose -f "$repo_root/infra/docker-compose.integration.yml" run --rm dev \
-  ./scripts/run-checks.sh --with-service-tests
+  ./scripts/run-checks.sh --service-tests-only

--- a/scripts/run-checks.sh
+++ b/scripts/run-checks.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 
-with_service_tests=0
+service_tests_only=0
 
 cargo_cmd=(cargo)
 if [[ -x "$repo_root/scripts/dev-cargo.sh" ]] && [[ -z "${LLVM_CONFIG_PATH:-}" ]] && [[ -z "${LLVM_SYS_221_PREFIX:-}" ]]; then
@@ -13,8 +13,8 @@ fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --with-service-tests)
-      with_service_tests=1
+    --service-tests-only)
+      service_tests_only=1
       shift
       ;;
     *)
@@ -45,13 +45,26 @@ run_step() {
 # or every program fails to link with "Could not locate the mux-runtime
 # library".
 run_step "cargo build" "${cargo_cmd[@]}" build -p mux-runtime -p mux-lang
-if [[ "$with_service_tests" == "1" ]]; then
-  run_step "cargo test" env MUX_RUN_SERVICE_TESTS=0 "${cargo_cmd[@]}" test -p mux-lang
-else
-  run_step "cargo test" "${cargo_cmd[@]}" test -p mux-lang
-fi
 
-if [[ "$with_service_tests" == "1" ]]; then
+# --service-tests-only runs the service_integration suite and nothing else.
+#
+# Its only caller is integration-checks.sh, which exists to reach postgres and
+# the echo servers from inside the compose "dev" container. That job runs in
+# parallel with Rust Checks, which already runs the full unit suite on the host
+# runner - so running the unit suite again in the container added roughly 180s
+# to every PR and every push while testing nothing the other job had not.
+#
+# The service suite is self-contained and does not depend on the unit run or on
+# the build above: tests/service_integration.rs builds its own mux-runtime and
+# drives the compiler through `cargo run` with
+# CARGO_TARGET_DIR=target/service-integration.
+#
+# MUX_RUN_SERVICE_TESTS is no longer forced to 0. It only existed to stop the
+# service tests firing during the general run that this branch no longer
+# performs; the container sets it to 1, which is what the suite below needs.
+if [[ "$service_tests_only" == "1" ]]; then
   run_step "cargo test --test service_integration" \
     "${cargo_cmd[@]}" test -p mux-lang --test service_integration -- --nocapture
+else
+  run_step "cargo test" "${cargo_cmd[@]}" test -p mux-lang
 fi


### PR DESCRIPTION
## What

`run-checks.sh --with-service-tests` becomes `--service-tests-only`, and runs the `service_integration` suite alone.

## Why

`integration-checks.sh` drives `run-checks.sh` inside the compose `dev` container so the tests can reach postgres and the echo servers. The old flag ran **the full unit suite first**, then the service suite:

```bash
run_step "cargo test" env MUX_RUN_SERVICE_TESTS=0 ... test -p mux-lang   # <- full unit suite
run_step "cargo test --test service_integration" ...                      # <- what we came for
```

`Rust Checks` already runs that same unit suite on the host runner, **in parallel**. So the container pass tested nothing new and added roughly **180s to every PR and every push**.

## Why the rename

`integration-checks.sh` is the only caller, and neither `CONTRIBUTING.md` nor `AGENTS.md` documents the flag. Renaming means a stale invocation fails loudly on `Unknown argument` rather than quietly running something different from what it used to.

## Why the service suite does not need the removed run

`tests/service_integration.rs` is self-contained. It builds its own `mux-runtime` and drives the compiler through `cargo run` with `CARGO_TARGET_DIR=target/service-integration`, entirely separate from the container's default target dir:

```rust
fn integration_target_dir() -> PathBuf { PathBuf::from("target/service-integration") }
```

`MUX_RUN_SERVICE_TESTS` is also no longer forced to `0`. It existed only to stop the service tests firing during the general run that no longer happens; the compose `dev` service sets it to `1`, which is what the remaining suite needs.

## What is deliberately left alone

The unit suite still runs **three** times per PR:

1. `run-checks.sh` -> `cargo test -p mux-lang`
2. `cargo insta test --unreferenced=reject`
3. `cargo llvm-cov`

Those three need different instrumentation and are all justified. Only the fourth run - the container one - was waste.

## Verification

Pre-commit ran the full suite locally: 53 + 84 unit, plus every integration target including `service_integration` (4 tests, self-skipping without `MUX_RUN_SERVICE_TESTS=1`). All green.

The real check is the `Integration Checks` job on this PR: it should still exercise all four service tests against live postgres/http/tcp/udp, and finish roughly 180s faster.