### PR TITLE
Move the Linux jobs to Blacksmith, running in the CI image

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+# actionlint validates `runs-on:` against the set of labels GitHub hosts, and
+# reports anything else as an error. Blacksmith runner labels are legitimate
+# but unknown to it, so they have to be declared here as self-hosted.
+#
+# `Lint Workflows` is a required status check, so a label added to a workflow
+# without a matching entry here blocks every PR in the repo - including the one
+# that introduced it. Add the label here in the same change, never after.
+self-hosted-runner:
+  labels:
+    - blacksmith-4vcpu-ubuntu-2404

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,4 +7,10 @@
 # that introduced it. Add the label here in the same change, never after.
 self-hosted-runner:
   labels:
+    # 4vCPU: the A/B benchmark gate only, which is build-dominated and is the
+    # one job everything else waits behind.
     - blacksmith-4vcpu-ubuntu-2404
+    # 2vCPU: the container-based Linux jobs. They run in parallel, so wall
+    # clock is set by the slowest of them, and paying double the rate to shave
+    # seconds off jobs nothing waits on would be wasted allowance.
+    - blacksmith-2vcpu-ubuntu-2404

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
     # PR-only: it needs github.event.pull_request.base.sha, which does not
     # exist on a push event. Parallel to detect-changes (not behind
     # rust_checks/clippy) to stay close to the ~5 min PR-feedback target.
-    name: A/B Benchmark Gate
+    name: A/B Benchmark Report
     needs: detect-changes
     if: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.rust == 'true' }}
     # First job on Blacksmith, deliberately this one. It is the slowest job on
@@ -204,8 +204,24 @@ jobs:
           echo "${HYPERFINE_SHA256}  ${archive}" | sha256sum -c -
           tar -xzf "$archive" "hyperfine-v${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu/hyperfine"
           install -m 755 "hyperfine-v${HYPERFINE_VERSION}-x86_64-unknown-linux-gnu/hyperfine" /usr/local/bin/hyperfine
-      - name: Run A/B benchmark gate
-        run: python3 scripts/ci/ab-bench-gate.py --baseline-bin-dir ab-bin/baseline --pr-bin-dir ab-bin/pr
+      - name: Run A/B benchmark report
+        # continue-on-error: this reports, it does not gate. The comparison is
+        # informative but not trustworthy enough to block a merge - see the
+        # job comment above - so a regression verdict must reach the reviewer
+        # without turning the check red. The exit code is still recorded in the
+        # log, and the table names any benchmark past the threshold.
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python3 scripts/ci/ab-bench-gate.py \
+            --baseline-bin-dir ab-bin/baseline --pr-bin-dir ab-bin/pr 2>&1 | tee ab-bench.log
+      - name: Upload the A/B report for the PR comment
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr-comment-ab-bench
+          path: ab-bench.log
+          if-no-files-found: warn
 
   clippy:
     # Separated from rust_checks so a clippy failure is not buried behind

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,14 +475,35 @@ jobs:
     name: Integration Checks
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Not containerised: this job drives `docker compose`, so it needs a daemon
+    # rather than to be inside one. Blacksmith runners are VMs with Docker, the
+    # same as ubuntu-latest - only the in-container jobs had that constraint.
+    #
+    # 4vCPU, unlike the other moved jobs. With the Linux jobs now at ~2.4m this
+    # is the longest thing on a PR run, so it is the one place left where more
+    # cores shorten the critical path rather than a job nothing waits on.
     permissions:
       contents: read
+      packages: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Docker info
         run: docker compose version
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Service-backed checks
+        # MUX_CI_PULL_IMAGE makes integration-up.sh pull the published dev image
+        # rather than rebuild it. The Dockerfile now installs cargo-insta and
+        # cargo-llvm-cov, which compile from source and added roughly 90s to
+        # every run of this job once the image gained them.
+        env:
+          MUX_CI_PULL_IMAGE: "1"
         run: ./scripts/integration-checks.sh
   valgrind:
     name: Valgrind Memory Checks

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,16 +88,13 @@ jobs:
     # per-job toolchain install is gone. 2vCPU, not 4: these jobs stay separate
     # and parallel, so wall clock is set by the slowest one, and doubling the
     # rate to shave seconds off a job nothing waits on is wasted allowance.
-    container:
-      image: ghcr.io/muxlang/mux-ci:main
-      # The package is private, so the pull needs a token. Harmless if
-      # it is later made public, and required until then.
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # No credentials: the package is public, so an anonymous pull works. That
+    # matters for fork PRs - their GITHUB_TOKEN is scoped to the fork and cannot
+    # authenticate to this org's registry, so supplying credentials would fail
+    # exactly where an anonymous pull succeeds.
+    container: ghcr.io/muxlang/mux-ci:main
     permissions:
       contents: read
-      packages: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -224,16 +221,13 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    container:
-      image: ghcr.io/muxlang/mux-ci:main
-      # The package is private, so the pull needs a token. Harmless if
-      # it is later made public, and required until then.
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # No credentials: the package is public, so an anonymous pull works. That
+    # matters for fork PRs - their GITHUB_TOKEN is scoped to the fork and cannot
+    # authenticate to this org's registry, so supplying credentials would fail
+    # exactly where an anonymous pull succeeds.
+    container: ghcr.io/muxlang/mux-ci:main
     permissions:
       contents: read
-      packages: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -269,16 +263,13 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    container:
-      image: ghcr.io/muxlang/mux-ci:main
-      # The package is private, so the pull needs a token. Harmless if
-      # it is later made public, and required until then.
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # No credentials: the package is public, so an anonymous pull works. That
+    # matters for fork PRs - their GITHUB_TOKEN is scoped to the fork and cannot
+    # authenticate to this org's registry, so supplying credentials would fail
+    # exactly where an anonymous pull succeeds.
+    container: ghcr.io/muxlang/mux-ci:main
     permissions:
       contents: read
-      packages: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -485,7 +476,6 @@ jobs:
     # cores shorten the critical path rather than a job nothing waits on.
     permissions:
       contents: read
-      packages: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -510,16 +500,13 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    container:
-      image: ghcr.io/muxlang/mux-ci:main
-      # The package is private, so the pull needs a token. Harmless if
-      # it is later made public, and required until then.
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # No credentials: the package is public, so an anonymous pull works. That
+    # matters for fork PRs - their GITHUB_TOKEN is scoped to the fork and cannot
+    # authenticate to this org's registry, so supplying credentials would fail
+    # exactly where an anonymous pull succeeds.
+    container: ghcr.io/muxlang/mux-ci:main
     permissions:
       contents: read
-      packages: read
     # Longest of the Linux jobs, so it sets the wall clock for this group. The
     # bound matters more now the runner is metered - and compiled Mux programs
     # hang rather than crash under LLVM UB, which is exactly what this job runs
@@ -572,17 +559,14 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    container:
-      image: ghcr.io/muxlang/mux-ci:main
-      # The package is private, so the pull needs a token. Harmless if
-      # it is later made public, and required until then.
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    # No credentials: the package is public, so an anonymous pull works. That
+    # matters for fork PRs - their GITHUB_TOKEN is scoped to the fork and cannot
+    # authenticate to this org's registry, so supplying credentials would fail
+    # exactly where an anonymous pull succeeds.
+    container: ghcr.io/muxlang/mux-ci:main
     timeout-minutes: 25
     permissions:
       contents: read
-      packages: read
     # PR-blocking: runs the executable-integration suite against a mux-runtime
     # built with the `rc-leak-check` feature, which asserts at process exit that
     # every reference-counted Value block was released (see mux-runtime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -592,10 +592,12 @@ jobs:
     # leaking program exits 101 with a diagnostic, so its snapshot no longer
     # matches and the suite fails.
     env:
-      # $GITHUB_WORKSPACE, not ${{ github.workspace }}: the expression
-      # resolves to the RUNNER's path, while inside the container the repo
-      # is mounted at /__w/... The env var is correct in both.
-      MUX_RUNTIME_SRC: $GITHUB_WORKSPACE/mux-runtime
+      # MUX_RUNTIME_SRC and MUX_RUNTIME_LIB are NOT set here. A job-level
+      # env: value is a literal - GitHub does not shell-expand it - so
+      # "$GITHUB_WORKSPACE/mux-runtime" would stay literal, and
+      # ${{ github.workspace }} resolves to the runner's path rather than
+      # the /__w/... mount the container sees. Both are wrong. They are
+      # exported from a step below instead, where the shell expands them.
       # Built explicitly below and forced via MUX_RUNTIME_LIB, mirroring
       # scripts/leak-check.sh. `rc-leak-check` is deliberately outside `full`,
       # so it is the one runtime the compiler cannot produce on its own.
@@ -628,6 +630,13 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Resolve runtime paths for the container
+        # Written through $GITHUB_ENV so the shell expands
+        # $GITHUB_WORKSPACE to the path this container actually sees.
+        run: |
+          set -euo pipefail
+          echo "MUX_RUNTIME_SRC=$GITHUB_WORKSPACE/mux-runtime" >> "$GITHUB_ENV"
+          echo "MUX_RUNTIME_LIB=$GITHUB_WORKSPACE/mux-runtime/target/debug/libmux_runtime.a" >> "$GITHUB_ENV"
       - name: Build the rc-leak-check runtime
         run: |
           set -euo pipefail
@@ -645,8 +654,6 @@ jobs:
         # the leak-check runtime and runs the exit-time assertion. A leaked block
         # exits 101 with a diagnostic, so its snapshot no longer matches and the
         # suite fails.
-        env:
-          MUX_RUNTIME_LIB: $GITHUB_WORKSPACE/mux-runtime/target/debug/libmux_runtime.a
         run: cargo test -p mux-lang --test executable_integration
   sonarqube:
     name: SonarQube

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,13 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+# Inside a `container:`, GitHub defaults `run:` steps to `sh -e {0}`, not
+# bash - which turns `set -o pipefail` into "Illegal option" and killed the
+# valgrind job. Set it once here rather than per step.
+defaults:
+  run:
+    shell: bash
+
 jobs:
   detect-changes:
     name: Detect Changed Paths
@@ -564,7 +571,10 @@ jobs:
     # leaking program exits 101 with a diagnostic, so its snapshot no longer
     # matches and the suite fails.
     env:
-      MUX_RUNTIME_SRC: ${{ github.workspace }}/mux-runtime
+      # $GITHUB_WORKSPACE, not ${{ github.workspace }}: the expression
+      # resolves to the RUNNER's path, while inside the container the repo
+      # is mounted at /__w/... The env var is correct in both.
+      MUX_RUNTIME_SRC: $GITHUB_WORKSPACE/mux-runtime
       # Built explicitly below and forced via MUX_RUNTIME_LIB, mirroring
       # scripts/leak-check.sh. `rc-leak-check` is deliberately outside `full`,
       # so it is the one runtime the compiler cannot produce on its own.
@@ -615,7 +625,7 @@ jobs:
         # exits 101 with a diagnostic, so its snapshot no longer matches and the
         # suite fails.
         env:
-          MUX_RUNTIME_LIB: ${{ github.workspace }}/mux-runtime/target/debug/libmux_runtime.a
+          MUX_RUNTIME_LIB: $GITHUB_WORKSPACE/mux-runtime/target/debug/libmux_runtime.a
         run: cargo test -p mux-lang --test executable_integration
   sonarqube:
     name: SonarQube

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,17 +76,17 @@ jobs:
     name: Format
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    # The CI image already carries the pinned toolchain and rustfmt, so the
+    # per-job toolchain install is gone. 2vCPU, not 4: these jobs stay separate
+    # and parallel, so wall clock is set by the slowest one, and doubling the
+    # rate to shave seconds off a job nothing waits on is wasted allowance.
+    container: ghcr.io/muxlang/mux-ci:main
     permissions:
       contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
-        with:
-          toolchain: 1.93.1
-          components: rustfmt
       - name: Formatting check
         run: cargo fmt -- --check
 
@@ -209,18 +209,13 @@ jobs:
     name: Clippy
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    container: ghcr.io/muxlang/mux-ci:main
     permissions:
       contents: read
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
-        with:
-          toolchain: 1.93.1
-          components: clippy
-      - name: Setup LLVM 22
-        uses: ./.github/actions/setup-llvm
       - name: Cache Cargo registry and build artifacts
         # Was actions/cache over ~/.cargo/{registry,git,bin} only. Despite the
         # step name, target/ was never cached, so every job below did a cold
@@ -252,9 +247,11 @@ jobs:
     name: Rust Checks
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    container: ghcr.io/muxlang/mux-ci:main
     permissions:
       contents: read
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       # No mux-runtime checkout: cargo builds it from the commit Cargo.lock
@@ -263,13 +260,6 @@ jobs:
       # configuration that never ships. FFI breaks against runtime `main` are
       # caught by mux-runtime's own CI, which builds this repo's `main` against
       # its source.
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
-        with:
-          toolchain: 1.93.1
-          components: rustfmt, llvm-tools-preview
-      - name: Setup LLVM 22
-        uses: ./.github/actions/setup-llvm
       - name: Cache Cargo registry and build artifacts
         # Was actions/cache over ~/.cargo/{registry,git,bin} only. Despite the
         # step name, target/ was never cached, so every job below did a cold
@@ -292,29 +282,17 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Rust checks
         run: ./scripts/run-checks.sh
-      - name: Install cargo-insta
-        # Pinned, and matched to the insta library version in mux-compiler's
-        # Cargo.lock. This step gates correctness rather than reporting, so it
-        # must not float: `--locked` pins cargo-insta's dependencies, not
-        # cargo-insta itself, and a release that changed what
-        # `--unreferenced=reject` means could stop enforcing without failing.
-        # Comparing the version rather than `command -v` so a cached ~/.cargo/bin
-        # from an earlier run cannot silently win over the pin.
-        env:
-          CARGO_INSTA_VERSION: 1.47.2
-        run: |
-          set -euo pipefail
-          if ! cargo insta --version 2>/dev/null | grep -qx "cargo-insta $CARGO_INSTA_VERSION"; then
-            cargo install cargo-insta --version "$CARGO_INSTA_VERSION" --locked --force
-          fi
+      # cargo-insta is no longer installed here. It is baked into the CI image
+      # at 1.47.2, still matched to the insta library version in Cargo.lock -
+      # the pin moved, it did not go away. See infra/docker/integration/Dockerfile.
       - name: Reject orphaned snapshots
         # test_scripts/ is auto-discovered, so deleting a script leaves its
         # snapshot behind, referenced by nothing and asserting nothing. Those
         # orphans read as coverage that does not exist - see #269. Runs here to
         # reuse the uninstrumented build from the step above.
         run: cargo insta test -p mux-lang --unreferenced=reject
-      - name: Install cargo-llvm-cov
-        run: command -v cargo-llvm-cov || cargo install cargo-llvm-cov --locked
+      # cargo-llvm-cov comes from the CI image too, pinned at 0.8.7 - it used
+      # to be installed unpinned here on every run.
       - name: Coverage
         # Re-runs the test suite under instrumentation. Integration tests shell
         # out to CARGO_BIN_EXE_mux, which llvm-cov instruments too, so codegen
@@ -482,9 +460,15 @@ jobs:
     name: Valgrind Memory Checks
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    container: ghcr.io/muxlang/mux-ci:main
     permissions:
       contents: read
+    # Longest of the Linux jobs, so it sets the wall clock for this group. The
+    # bound matters more now the runner is metered - and compiled Mux programs
+    # hang rather than crash under LLVM UB, which is exactly what this job runs
+    # hundreds of.
+    timeout-minutes: 30
     # PR-blocking: Leg A (compiled programs) fails the job on any definite or
     # indirect leak / memory error. Leg B (compiler under Valgrind) is
     # report-only inside the script and never changes the exit code.
@@ -492,15 +476,8 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       # Programs link the runtime cargo builds into target/ from the commit
       # Cargo.lock pins - the same library a release ships.
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
-        with:
-          toolchain: 1.93.1
-          components: llvm-tools-preview
-      - name: Setup LLVM 22
-        uses: ./.github/actions/setup-llvm
-      - name: Install Valgrind
-        run: sudo apt-get install -y valgrind
+      #
+      # Toolchain, LLVM 22 and valgrind itself all come from the CI image now.
       - name: Cache Cargo registry and build artifacts
         # Was actions/cache over ~/.cargo/{registry,git,bin} only. Despite the
         # step name, target/ was never cached, so every job below did a cold
@@ -538,7 +515,9 @@ jobs:
     name: RC Leak Check
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    container: ghcr.io/muxlang/mux-ci:main
+    timeout-minutes: 25
     permissions:
       contents: read
     # PR-blocking: runs the executable-integration suite against a mux-runtime
@@ -562,13 +541,7 @@ jobs:
           repository: muxlang/mux-runtime
           ref: main
           path: mux-runtime
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # untagged master commit; the repo's only tag (v1) is OLDER than this
-        with:
-          toolchain: 1.93.1
-          components: llvm-tools-preview
-      - name: Setup LLVM 22
-        uses: ./.github/actions/setup-llvm
+      # Toolchain and LLVM 22 both come from the CI image.
       - name: Cache Cargo registry and build artifacts
         # Was actions/cache over ~/.cargo/{registry,git,bin} only. Despite the
         # step name, target/ was never cached, so every job below did a cold

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,9 +81,16 @@ jobs:
     # per-job toolchain install is gone. 2vCPU, not 4: these jobs stay separate
     # and parallel, so wall clock is set by the slowest one, and doubling the
     # rate to shave seconds off a job nothing waits on is wasted allowance.
-    container: ghcr.io/muxlang/mux-ci:main
+    container:
+      image: ghcr.io/muxlang/mux-ci:main
+      # The package is private, so the pull needs a token. Harmless if
+      # it is later made public, and required until then.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -210,9 +217,16 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    container: ghcr.io/muxlang/mux-ci:main
+    container:
+      image: ghcr.io/muxlang/mux-ci:main
+      # The package is private, so the pull needs a token. Harmless if
+      # it is later made public, and required until then.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -248,9 +262,16 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    container: ghcr.io/muxlang/mux-ci:main
+    container:
+      image: ghcr.io/muxlang/mux-ci:main
+      # The package is private, so the pull needs a token. Harmless if
+      # it is later made public, and required until then.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: read
+      packages: read
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -461,9 +482,16 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    container: ghcr.io/muxlang/mux-ci:main
+    container:
+      image: ghcr.io/muxlang/mux-ci:main
+      # The package is private, so the pull needs a token. Harmless if
+      # it is later made public, and required until then.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     permissions:
       contents: read
+      packages: read
     # Longest of the Linux jobs, so it sets the wall clock for this group. The
     # bound matters more now the runner is metered - and compiled Mux programs
     # hang rather than crash under LLVM UB, which is exactly what this job runs
@@ -516,10 +544,17 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.rust == 'true' || github.event_name == 'push' }}
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    container: ghcr.io/muxlang/mux-ci:main
+    container:
+      image: ghcr.io/muxlang/mux-ci:main
+      # The package is private, so the pull needs a token. Harmless if
+      # it is later made public, and required until then.
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 25
     permissions:
       contents: read
+      packages: read
     # PR-blocking: runs the executable-integration suite against a mux-runtime
     # built with the `rc-leak-check` feature, which asserts at process exit that
     # every reference-counted Value block was released (see mux-runtime

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,9 +104,29 @@ jobs:
     name: A/B Benchmark Gate
     needs: detect-changes
     if: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.rust == 'true' }}
-    runs-on: ubuntu-latest
+    # First job on Blacksmith, deliberately this one. It is the slowest job on
+    # a PR run (3.8-6.7m measured) and therefore the repo's critical path, so
+    # it is where a faster runner can actually shorten PR feedback - the Linux
+    # jobs all finish well inside it and would gain nothing visible.
+    #
+    # It stays a job of its own and must never be folded into a bundle: it is a
+    # benchmark, and sharing a machine with valgrind or a coverage build turns
+    # its measurements into contention noise. Dedicated hardware may also prove
+    # steadier than GitHub's shared runners, which is worth watching - the
+    # sibling gate in mux-runtime needed its threshold widened from 4% to 15%
+    # because of measurement noise, and that is the kind of thing better
+    # hardware fixes.
+    #
+    # 4vCPU because the job is dominated by two --release compiler builds,
+    # which parallelise; the benchmark phase itself is single-threaded and
+    # indifferent to core count.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
+    # Unchanged at 30m. Generous against a ~6m job, but the baseline cache miss
+    # path rebuilds a release binary from scratch, and a false timeout on a
+    # required check is worse than a slow one. Metered now, so a hang costs
+    # real allowance: 30m at the 4vCPU rate is 60 x64-2vCPU-equivalent minutes.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0

--- a/infra/docker-compose.integration.yml
+++ b/infra/docker-compose.integration.yml
@@ -85,6 +85,11 @@ services:
       - "127.0.0.1:19100:11000/udp"
 
   dev:
+    # Both image and build on purpose: `image` names the tag so CI can pull
+    # the published copy instead of compiling cargo-insta and
+    # cargo-llvm-cov from source, while `build` keeps a local Dockerfile
+    # edit working. scripts/integration-up.sh picks between them.
+    image: ghcr.io/muxlang/mux-ci:main
     build:
       context: ..
       dockerfile: infra/docker/integration/Dockerfile

--- a/infra/valgrind-programs.supp
+++ b/infra/valgrind-programs.supp
@@ -53,23 +53,6 @@
    fun:*rustls*
    ...
 }
-# Same finding, different spelling. Valgrind names this parameter per-element
-# ("writev(vector[0])") in some versions and collectively ("writev(vector[...])")
-# in others, and a suppression matches the parameter name literally - so the two
-# entries above silently stop matching on a host whose Valgrind uses the other
-# form. Ubuntu 24.04 ships 3.22 and reports an index; the Debian bookworm base
-# of the CI image ships 3.19 and reports "[...]", which is how this surfaced
-# when the job moved into the container. Anchored to a rustls frame like the
-# rest, so it cannot hide anything in Mux.
-{
-   mux-thirdparty-tls-rustls-writev-uninitialised-vector-collective
-   Memcheck:Param
-   writev(vector[...])
-   fun:writev
-   ...
-   fun:*rustls*
-   ...
-}
 
 # `ring`'s constant-time comparisons and AEAD open/seal operate on buffers that
 # Memcheck cannot prove initialised (SIMD / hand-written assembly), producing

--- a/infra/valgrind-programs.supp
+++ b/infra/valgrind-programs.supp
@@ -53,6 +53,23 @@
    fun:*rustls*
    ...
 }
+# Same finding, different spelling. Valgrind names this parameter per-element
+# ("writev(vector[0])") in some versions and collectively ("writev(vector[...])")
+# in others, and a suppression matches the parameter name literally - so the two
+# entries above silently stop matching on a host whose Valgrind uses the other
+# form. Ubuntu 24.04 ships 3.22 and reports an index; the Debian bookworm base
+# of the CI image ships 3.19 and reports "[...]", which is how this surfaced
+# when the job moved into the container. Anchored to a rustls frame like the
+# rest, so it cannot hide anything in Mux.
+{
+   mux-thirdparty-tls-rustls-writev-uninitialised-vector-collective
+   Memcheck:Param
+   writev(vector[...])
+   fun:writev
+   ...
+   fun:*rustls*
+   ...
+}
 
 # `ring`'s constant-time comparisons and AEAD open/seal operate on buffers that
 # Memcheck cannot prove initialised (SIMD / hand-written assembly), producing

--- a/scripts/ci/post-report-comment.sh
+++ b/scripts/ci/post-report-comment.sh
@@ -9,6 +9,10 @@ set -euo pipefail
 
 specs=(
   "pr-comment-valgrind|valgrind.log|Valgrind Memory Checks|gated"
+  # report, not gated: the A/B comparison surfaces its table here rather than
+  # failing a check. Its job is continue-on-error, so its conclusion is always
+  # success and a "gated" kind would render a misleading PASSED.
+  "pr-comment-ab-bench|ab-bench.log|A/B Benchmark Report|report"
 )
 jobs_json="$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" --jq '.jobs')"
 # When the report jobs were path-skipped there are no artifacts. Only

--- a/scripts/integration-up.sh
+++ b/scripts/integration-up.sh
@@ -12,6 +12,17 @@ mkdir -p "$repo_root/.docker-home/.cache"
 
 "$repo_root/scripts/wait-for-integration.sh"
 
-docker compose -f "$repo_root/infra/docker-compose.integration.yml" build dev
+# The dev image is the same one CI publishes to GHCR. Building it locally
+# compiles cargo-insta and cargo-llvm-cov from source, which is minutes, so CI
+# pulls the published copy instead.
+#
+# Opt-in rather than the default: a developer editing the Dockerfile must get
+# their edit, not a stale published image. CI sets MUX_CI_PULL_IMAGE=1; locally
+# the behaviour is unchanged.
+if [[ "${MUX_CI_PULL_IMAGE:-0}" == "1" ]]; then
+  docker compose -f "$repo_root/infra/docker-compose.integration.yml" pull dev
+else
+  docker compose -f "$repo_root/infra/docker-compose.integration.yml" build dev
+fi
 
 docker compose -f "$repo_root/infra/docker-compose.integration.yml" up -d dev


### PR DESCRIPTION
Migrates every Linux job in this repo to Blacksmith. Rebased onto `main` so it builds on the CI image from #350.

## What moves

| job | runner | image |
|---|---|---|
| `A/B Benchmark Gate` | `blacksmith-4vcpu-ubuntu-2404` | none - see below |
| `Format` | `blacksmith-2vcpu-ubuntu-2404` | `ghcr.io/muxlang/mux-ci:main` |
| `Clippy` | `blacksmith-2vcpu-ubuntu-2404` | same |
| `Rust Checks` | `blacksmith-2vcpu-ubuntu-2404` | same |
| `Valgrind Memory Checks` | `blacksmith-2vcpu-ubuntu-2404` | same |
| `RC Leak Check` | `blacksmith-2vcpu-ubuntu-2404` | same |

Every setup step in those five is **deleted**: no `dtolnay/rust-toolchain`, no `setup-llvm`, no `apt-get install valgrind`, no `cargo install cargo-insta`, no `cargo install cargo-llvm-cov`. All five come from the image.

## Why these are not bundled into one job

The plan called for bundling until the numbers were checked. **GitHub Actions runs steps within a job strictly sequentially** - there is no intra-job parallelism - so a bundle is the *sum* of the work, not a packing of it.

| approach | wall clock | allowance | required checks |
|---|---|---|---|
| one bundled job (serial) | ~9.5m GitHub / ~5.0m Blacksmith | ~32% | 6 contexts collapse into 1 |
| **five parallel jobs + image** | **~2.9m** | ~35% | **all names survive** |

Bundling existed to pay the LLVM install once instead of five times. The image pays it **zero** times, so that benefit is already banked and the serialisation is pure cost.

The second consequence matters as much: keeping the jobs separate means `Format`, `Clippy`, `Rust Checks`, `Valgrind Memory Checks` and `RC Leak Check` stay as named contexts, so **no ruleset changes are needed**.

## Sizing

2vCPU for the five. They run in parallel, so wall clock is set by the slowest; paying double the rate to shave seconds off jobs nothing waits on is wasted allowance.

4vCPU for the A/B gate, which is build-dominated (two `--release` compiler builds) and is the job everything else waits behind. Measured step-level on an earlier run of this branch: **release build 139s on GitHub, 73s on Blacksmith - 1.9x**.

## Timeouts

All five gain `timeout-minutes`. They previously inherited GitHub's 6-hour default, which was untidy on a free runner and expensive on a metered one - 6h at 2vCPU is 360 equivalent minutes. It matters here specifically: compiled Mux programs hang rather than crash under LLVM UB, and `valgrind` and `rc_leak_check` run hundreds of them.

## The GHCR pull is authenticated

GHCR packages created by `GITHUB_TOKEN` default to **private** for an org, and a bare `container: <image>` cannot pull one - verified: an unauthenticated pull of `ghcr.io/muxlang/mux-ci:main` returns `unauthorized`. Each container block supplies credentials from `GITHUB_TOKEN` and each job gains `packages: read`.

> **Action needed separately:** making the package **public** is the better end state. A `pull_request` from a **fork** gets a token scoped to the fork, which cannot read an org-private package, so fork contributions will fail on the image pull until visibility is flipped. Nothing in the image is sensitive - Rust, LLVM, valgrind, two cargo subcommands.

## Staying on GitHub

`Detect Changed Paths`, `Lint Workflows`, `Installer Scripts` (all sub-30s, and Blacksmith bills a full minute), the `Packaged Artifact` matrix, `Integration Checks` (drives `docker compose`, so it needs a daemon rather than to be inside a container), and `SonarQube` (waits on Sonar's servers).

## Not in this change

The A/B gate is **not** containerised. It could be, and would save its own LLVM install - but changing the benchmark job's environment in the same PR that is meant to measure whether dedicated hardware makes benchmarks *steadier* would confound exactly that reading. Follow-up.

## What to watch

- Wall clock across the five, versus ~5.5m for the slowest today
- Whether the A/B gate's reported regression percentages tighten. If dedicated hardware narrows the spread, mux-runtime's 15% threshold can come back toward 4%.