### PR TITLE
Add valgrind and the cargo tools to the CI image, and publish it to GHCR

### DIFF
--- a/.github/workflows/publish-ci-image.yml
+++ b/.github/workflows/publish-ci-image.yml
@@ -1,0 +1,68 @@
+# Publish the CI image to GHCR.
+#
+# The image is the environment CI's bundled Linux job runs inside, so the jobs
+# that used to each install LLVM, cargo-insta and cargo-llvm-cov now inherit
+# them from a layer that was built once.
+#
+# Push-only, never on pull_request: a fork PR must not be able to publish an
+# image that the base repo's own CI then executes. A PR that edits the
+# Dockerfile is still validated - the build job below runs without pushing -
+# so a broken Dockerfile fails review rather than main.
+name: Publish CI image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "infra/docker/integration/Dockerfile"
+      - ".github/workflows/publish-ci-image.yml"
+  pull_request:
+    paths:
+      - "infra/docker/integration/Dockerfile"
+      - ".github/workflows/publish-ci-image.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish CI image
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        # Skipped on pull_request, where the build below runs without pushing.
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: infra/docker/integration/Dockerfile
+          # Pushed only from main. A PR build proves the Dockerfile still
+          # builds without publishing anything.
+          push: ${{ github.event_name != 'pull_request' }}
+          # Two tags on purpose. `main` is what the bundled job pulls, so a
+          # merge here updates CI everywhere at once; the commit SHA gives a
+          # fixed reference to roll back to or to pin a bisect against.
+          tags: |
+            ghcr.io/muxlang/mux-ci:main
+            ghcr.io/muxlang/mux-ci:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/infra/docker/integration/Dockerfile
+++ b/infra/docker/integration/Dockerfile
@@ -1,3 +1,19 @@
+# The CI image: a complete Rust + LLVM 22 environment for this repo.
+#
+# Two consumers, deliberately the same image so they cannot drift:
+#   - docker-compose.integration.yml's `dev` service, which needs to reach the
+#     postgres and echo-server containers.
+#   - CI's bundled Linux job, which runs `container:` against the published
+#     copy at ghcr.io/muxlang/mux-ci and so does not install LLVM, cargo-insta
+#     or cargo-llvm-cov per job the way the split jobs each did.
+#
+# Published by .github/workflows/publish-ci-image.yml on any change to this
+# file. Compose still builds it locally, so a local edit takes effect without
+# waiting for a publish.
+#
+# Every tool version here is pinned. This image gates correctness, not just
+# convenience, and a floating tool changes what CI enforces without any commit
+# saying so.
 FROM rust:1.93.1-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -16,13 +32,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         clang-22 \
         libpolly-22-dev \
         llvm-22-dev \
-    && rustup component add clippy rustfmt \
+        valgrind \
+    && rustup component add clippy rustfmt llvm-tools-preview \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 1000 mux \
     && useradd --uid 1000 --gid mux --shell /bin/bash --create-home mux
 
-USER mux
+# cargo-insta is matched to the `insta` library version in Cargo.lock (1.47.2).
+# It gates correctness rather than reporting - `--unreferenced=reject` is what
+# catches orphaned snapshots - so a release that changed what that flag means
+# could stop enforcing without failing. Move this pin and the lockfile together.
+#
+# cargo-llvm-cov was previously installed unpinned in CI. Pinned here so the
+# image is reproducible; llvm-tools-preview above is its prerequisite.
+RUN cargo install cargo-insta --version 1.47.2 --locked \
+    && cargo install cargo-llvm-cov --version 0.8.7 --locked \
+    && rm -rf "${CARGO_HOME:-/usr/local/cargo}/registry" "${CARGO_HOME:-/usr/local/cargo}/git"
 
+# No USER directive, on purpose. Compose sets `user:` explicitly for the dev
+# service (LOCAL_UID/LOCAL_GID, so bind-mounted files keep the caller's
+# ownership), and GitHub Actions needs to write to a workspace it mounts as
+# root. Baking a non-root default would break the second without helping the
+# first. The mux user still exists for compose to select.
 ENV LLVM_SYS_221_PREFIX=/usr/lib/llvm-22 \
     LLVM_CONFIG_PATH=/usr/bin/llvm-config-22 \
     LLVM_SYS_221_STRICT_VERSIONING=1 \


### PR DESCRIPTION
Groundwork for bundling the Linux jobs into one. No CI behaviour changes yet - this only makes the image the bundle will run inside.

## Why

Today `clippy`, `rust_checks`, `valgrind` and `rc_leak_check` each install LLVM separately. Measured on the Blacksmith A/B gate run, that step is **15s per job, paid four times**. `rust_checks` additionally installs `cargo-insta` and `cargo-llvm-cov` at run time.

Baking all of it into the image removes that per-job cost entirely, which is the main thing bundling buys.

## What changed

The image already existed for docker-compose's integration `dev` service, with Rust 1.93.1, LLVM 22, clang-22, clippy and rustfmt. Added:

| addition | why |
|---|---|
| `valgrind` | for the valgrind job |
| `cargo-insta` **1.47.2** | matched to the `insta` version in `Cargo.lock` |
| `cargo-llvm-cov` **0.8.7** | was unpinned in CI; pinned so the image is reproducible |
| `llvm-tools-preview` | required by cargo-llvm-cov |

`cargo-insta` gates correctness rather than reporting - `--unreferenced=reject` is what catches orphaned snapshots - so **this pin and the lockfile move together**. Note the newest release is 1.48.0; that is deliberately not used.

## The `USER` directive is removed

It was already being overridden: compose sets `user:` explicitly for the dev service (`LOCAL_UID`/`LOCAL_GID`, so bind-mounted files keep the caller's ownership). And a GitHub Actions `container:` must be able to write a workspace that Actions mounts as root, which a non-root default breaks. The `mux` user still exists for compose to select.

## One image, two consumers

The bundled CI job and the integration `dev` service share it on purpose, so the environment CI enforces and the environment integration tests run in cannot drift apart. Compose still builds locally, so a local Dockerfile edit takes effect without waiting for a publish.

## Publishing

`publish-ci-image.yml` pushes to `ghcr.io/muxlang/mux-ci` on pushes to `main` touching the Dockerfile, tagged both `main` (what the bundled job will pull) and the commit SHA (a fixed reference for rollback or bisect).

It deliberately **does not push on `pull_request`** - a fork PR must not be able to publish an image the base repo's CI then executes. It does still *build* there, so a broken Dockerfile fails review rather than `main`.

## Verified locally

Image builds clean. Inside it:

```
user=root uid=0
rustc 1.93.1 (01f6ddf75 2026-02-11)
cargo-insta 1.47.2
cargo-llvm-cov 0.8.7
valgrind-3.19.0
22.1.8                          # llvm-config-22
LLVM_SYS_221_PREFIX=/usr/lib/llvm-22 CC=clang-22
components: clippy rustfmt llvm-tools ...
```

One trap worth knowing for later: `docker run ... bash -lc` loses `/usr/local/cargo/bin` because a login shell rebuilds PATH. Actions `run:` steps use a non-login shell, so this does not affect CI - but it will bite anyone debugging the image by hand.