### PR TITLE
Pin Valgrind 3.22.0 in the CI image

### DIFF
--- a/infra/docker/integration/Dockerfile
+++ b/infra/docker/integration/Dockerfile
@@ -32,11 +32,42 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         clang-22 \
         libpolly-22-dev \
         llvm-22-dev \
-        valgrind \
+        bzip2 \
+        libc6-dbg \
     && rustup component add clippy rustfmt llvm-tools-preview \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 1000 mux \
     && useradd --uid 1000 --gid mux --shell /bin/bash --create-home mux
+
+# Valgrind is built from source at a pinned version rather than taken from apt.
+#
+# Debian bookworm ships 3.19, which names the writev parameter collectively
+# ("writev(vector[...])"). Ubuntu 24.04 - what the GitHub runners used - ships
+# 3.22, which names it per element ("writev(vector[0])"). Suppressions match
+# that name LITERALLY, so infra/valgrind-programs.supp, written and validated
+# against 3.22, silently stopped matching under 3.19 and the TLS false
+# positives in test_std_http.mux began failing the gate.
+#
+# Both spellings were confirmed by running the same writev repro under each
+# version. Pinning 3.22.0 reproduces the behaviour the suppression file was
+# written for, and pins it - previously this tracked whatever the base image
+# happened to carry, which is how the skew appeared in the first place.
+#
+# If this is ever bumped, re-check that the suppressions still match; the
+# parameter naming is not a stable interface.
+ARG VALGRIND_VERSION=3.22.0
+ARG VALGRIND_SHA256=c811db5add2c5f729944caf47c4e7a65dcaabb9461e472b578765dd7bf6d2d4c
+RUN set -eux; \
+    cd /tmp; \
+    curl -fsSL --proto '=https' -O "https://sourceware.org/pub/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2"; \
+    echo "${VALGRIND_SHA256}  valgrind-${VALGRIND_VERSION}.tar.bz2" | sha256sum -c -; \
+    tar -xf "valgrind-${VALGRIND_VERSION}.tar.bz2"; \
+    cd "valgrind-${VALGRIND_VERSION}"; \
+    ./configure --prefix=/usr/local >/dev/null; \
+    make -j"$(nproc)" >/dev/null; \
+    make install >/dev/null; \
+    cd /; rm -rf "/tmp/valgrind-${VALGRIND_VERSION}" "/tmp/valgrind-${VALGRIND_VERSION}.tar.bz2"; \
+    valgrind --version
 
 # cargo-insta is matched to the `insta` library version in Cargo.lock (1.47.2).
 # It gates correctness rather than reporting - `--unreferenced=reject` is what


### PR DESCRIPTION
Split out of #349 so the image can publish **before** the workflow that depends on it. Merge this first.

## Why it must be its own PR

The migration's Valgrind job pulls `ghcr.io/muxlang/mux-ci:main`, and `publish-ci-image.yml` only pushes that tag on a push to `main`. So a Dockerfile fix and its consumer cannot land together - #349 is currently red for exactly this reason, running the fix against the previously-published image.

## The bug

Valgrind names the `writev` parameter differently between versions, and suppressions match that name **literally**:

| version | reports |
|---|---|
| 3.19.0 - Debian bookworm, the image base | `writev(vector[...])` |
| 3.22.0 - Ubuntu 24.04, the GitHub runners | `writev(vector[0])`, `writev(vector[1])` |

`infra/valgrind-programs.supp` was written and validated against 3.22. Moving the job into a bookworm-based container silently invalidated its entries, and the third-party rustls/ring TLS false positives in `test_std_http.mux` began failing the gate:

```
FAIL  test_std_http.mux  [MEMORY-ERROR]
==4547== Syscall param writev(vector[...]) points to uninitialised byte(s)
   ... rustls::crypto::ring::tls13::Tls13MessageEncrypter::encrypt
113 program(s), 1 failure(s)
```

The finding is **neither new nor in Mux code** - every frame is `ureq` / `rustls` / `ring`. The suppression simply stopped applying.

## Why pin rather than suppress

Adding the second spelling would work, but it hides the cause and leaves the file carrying two forms of one entry for a reason nobody can see later. Pinning fixes it at the source.

It also removes the drift that caused this: the previous `apt install valgrind` tracked whatever the base image happened to ship. The version is now explicit and checksum-verified.

**No suppression is added or changed** - the file stays at 7 entries.

## Verified empirically

Same `writev` repro run under each version rather than assuming:

- 3.19 → `vector[...]`
- 3.22 → `vector[0]`, `vector[1]`
- rebuilt image → reports the indexed form, and a suppression using that spelling matches (0 reports remaining)
- `rustc 1.93.1`, `cargo-insta 1.47.2`, `cargo-llvm-cov 0.8.7` all still intact

Also confirmed `test_std_http.mux` passed on GitHub with 113 programs / 0 failures, so the TLS path was always exercised there and the suppression was always doing real work - ruling out the theory that the container merely enabled network access the runner lacked.

## Note on the bump

The `ARG VALGRIND_VERSION` / `ARG VALGRIND_SHA256` pair is deliberate. If it is ever bumped, re-check that the suppressions still match - the parameter naming is not a stable interface.