### PR TITLE
Emit deterministic LLVM IR

### DIFF
--- a/mux-compiler/src/codegen/mod.rs
+++ b/mux-compiler/src/codegen/mod.rs
@@ -26,7 +26,7 @@ use inkwell::targets::{
 };
 use inkwell::types::BasicTypeEnum;
 use inkwell::values::{BasicValueEnum, FunctionValue, PointerValue};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::ast::{
     AstNode, EnumVariantField, Field, FunctionNode, ImportSpec, StatementKind, StatementNode,
@@ -104,7 +104,13 @@ pub struct CodeGenerator<'a> {
     /// or `None` for the main module (whose globals keep unqualified symbols).
     current_module_prefix: Option<String>,
     functions: HashMap<String, FunctionValue<'a>>,
-    function_nodes: HashMap<String, FunctionNode>,
+    /// Every function AST node, keyed by name. Ordered, because
+    /// `generate_specialized_methods` walks it to decide which methods to
+    /// monomorphize and emits them in the order it finds them. A `HashMap`
+    /// there made the emitted IR differ byte-for-byte between back-to-back
+    /// builds of the same file, since Rust randomizes hash iteration per
+    /// process (issue #344).
+    function_nodes: BTreeMap<String, FunctionNode>,
     current_function_name: Option<String>,
     current_function_return_type: Option<ResolvedType>,
     generic_context: Option<GenericContext>,
@@ -731,7 +737,7 @@ impl<'a> CodeGenerator<'a> {
             module_globals: HashMap::new(),
             current_module_prefix: None,
             functions: HashMap::new(),
-            function_nodes: HashMap::new(),
+            function_nodes: BTreeMap::new(),
             current_function_name: None,
             current_function_return_type: None,
             generic_context: None,

--- a/mux-compiler/src/codegen/mod.rs
+++ b/mux-compiler/src/codegen/mod.rs
@@ -686,7 +686,6 @@ impl<'a> CodeGenerator<'a> {
         type_map.insert("optional".to_string(), struct_type.into());
         type_map.insert("result".to_string(), struct_type.into());
 
-        use std::collections::BTreeMap;
         let mut ordered_variants = BTreeMap::new();
         ordered_variants.insert(
             "optional".to_string(),
@@ -701,13 +700,16 @@ impl<'a> CodeGenerator<'a> {
             enum_variants.insert(enum_name, variants);
         }
 
+        // Seed from the symbol's declared variant order, not from `methods`.
+        // Position in this vector is the discriminant (`get_variant_index`), and
+        // `methods` is a HashMap, so seeding from its keys made discriminants
+        // depend on hash order. `generate_enum_type` overwrites each entry with
+        // declaration order before anything reads it, which is why that was
+        // never observable - but it left a hash-ordered vector feeding
+        // discriminants one refactor away from mattering (issue #344).
         for (name, symbol) in analyzer.all_symbols() {
             if symbol.kind == crate::semantics::SymbolKind::Enum {
-                let mut variants = vec![];
-                for method_name in symbol.methods.keys() {
-                    variants.push(method_name.clone());
-                }
-                enum_variants.insert(name.clone(), variants);
+                enum_variants.insert(name.clone(), symbol.variants.clone().unwrap_or_default());
             }
         }
 

--- a/mux-compiler/src/codegen/where_clause.rs
+++ b/mux-compiler/src/codegen/where_clause.rs
@@ -181,7 +181,7 @@ impl<'a> CodeGenerator<'a> {
             .get(class_name)
             .ok_or_else(|| format!("Class {} not found in field types map", class_name))?
             .clone();
-        let field_semantic_types: Vec<(String, Type)> = {
+        let mut field_semantic_types: Vec<(String, Type)> = {
             let class_symbol = self
                 .analyzer
                 .symbol_table()
@@ -193,6 +193,10 @@ impl<'a> CodeGenerator<'a> {
                 .map(|(name, (ty, _))| (name.clone(), ty.clone()))
                 .collect()
         };
+        // Bind in struct order. `fields` is a HashMap, so without this the GEPs
+        // below came out in a different order between builds of the same file
+        // (issue #344). Struct order is also what a reader of the IR expects.
+        field_semantic_types.sort_by_key(|(name, _)| field_indices.get(name).copied());
 
         for (field_name, semantic_type) in field_semantic_types {
             let Some(&index) = field_indices.get(&field_name) else {

--- a/mux-compiler/src/semantics/free_vars.rs
+++ b/mux-compiler/src/semantics/free_vars.rs
@@ -10,7 +10,11 @@ impl SemanticAnalyzer {
         body: &[StatementNode],
         local_vars: &std::collections::HashSet<String>,
     ) -> Result<Vec<(String, Type)>, SemanticError> {
-        let mut free_vars = std::collections::HashMap::new();
+        // Ordered: the collected order becomes the closure's capture list, and
+        // so the layout of its environment struct. A HashMap here made the
+        // emitted IR differ between back-to-back builds of the same file
+        // (issue #344).
+        let mut free_vars = std::collections::BTreeMap::new();
         let mut local_vars = local_vars.clone();
 
         for stmt in body {
@@ -27,7 +31,7 @@ impl SemanticAnalyzer {
         exprs: &[ExpressionNode],
         local_vars: &std::collections::HashSet<String>,
     ) -> Result<Vec<(String, Type)>, SemanticError> {
-        let mut free_vars = std::collections::HashMap::new();
+        let mut free_vars = std::collections::BTreeMap::new();
 
         for expr in exprs {
             self.find_free_variables_in_expression(expr, local_vars, &mut free_vars)?;
@@ -40,7 +44,7 @@ impl SemanticAnalyzer {
         &self,
         stmt: &StatementNode,
         local_vars: &mut std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         match &stmt.kind {
             StatementKind::Expression(expr) | StatementKind::Return(Some(expr)) => {
@@ -83,7 +87,7 @@ impl SemanticAnalyzer {
         name: &str,
         expr: &ExpressionNode,
         local_vars: &mut std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         // First analyze the expression (uses happen before the decl is in scope)
         self.find_free_variables_in_expression(expr, local_vars, free_vars)?;
@@ -98,7 +102,7 @@ impl SemanticAnalyzer {
         then_block: &[StatementNode],
         else_block: &Option<Vec<StatementNode>>,
         local_vars: &mut std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(cond, local_vars, free_vars)?;
         for s in then_block {
@@ -117,7 +121,7 @@ impl SemanticAnalyzer {
         cond: &ExpressionNode,
         body: &[StatementNode],
         local_vars: &mut std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(cond, local_vars, free_vars)?;
         for s in body {
@@ -132,7 +136,7 @@ impl SemanticAnalyzer {
         iter: &ExpressionNode,
         body: &[StatementNode],
         local_vars: &mut std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(iter, local_vars, free_vars)?;
         // Iterator variable is local to the for loop
@@ -147,7 +151,7 @@ impl SemanticAnalyzer {
         &self,
         stmts: &[StatementNode],
         local_vars: &mut std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         for s in stmts {
             self.find_free_variables_in_statement(s, local_vars, free_vars)?;
@@ -159,7 +163,7 @@ impl SemanticAnalyzer {
         &self,
         expr: &ExpressionNode,
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         match &expr.kind {
             ExpressionKind::Identifier(name) => {
@@ -215,7 +219,7 @@ impl SemanticAnalyzer {
         &self,
         name: &str,
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         // Check if it's a local variable (parameter or declared in lambda body)
         if !local_vars.contains(name) {
@@ -235,7 +239,7 @@ impl SemanticAnalyzer {
         left: &ExpressionNode,
         right: &ExpressionNode,
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(left, local_vars, free_vars)?;
         self.find_free_variables_in_expression(right, local_vars, free_vars)?;
@@ -246,7 +250,7 @@ impl SemanticAnalyzer {
         &self,
         inner: &ExpressionNode,
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(inner, local_vars, free_vars)?;
         Ok(())
@@ -257,7 +261,7 @@ impl SemanticAnalyzer {
         func: &ExpressionNode,
         args: &[ExpressionNode],
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(func, local_vars, free_vars)?;
         for arg in args {
@@ -270,7 +274,7 @@ impl SemanticAnalyzer {
         &self,
         inner: &ExpressionNode,
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(inner, local_vars, free_vars)?;
         Ok(())
@@ -281,7 +285,7 @@ impl SemanticAnalyzer {
         inner: &ExpressionNode,
         index: &ExpressionNode,
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(inner, local_vars, free_vars)?;
         self.find_free_variables_in_expression(index, local_vars, free_vars)?;
@@ -292,7 +296,7 @@ impl SemanticAnalyzer {
         &self,
         elements: &[ExpressionNode],
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         for elem in elements {
             self.find_free_variables_in_expression(elem, local_vars, free_vars)?;
@@ -304,7 +308,7 @@ impl SemanticAnalyzer {
         &self,
         entries: &[(ExpressionNode, ExpressionNode)],
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         for (key, val) in entries {
             self.find_free_variables_in_expression(key, local_vars, free_vars)?;
@@ -317,7 +321,7 @@ impl SemanticAnalyzer {
         &self,
         elements: &[ExpressionNode],
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         for elem in elements {
             self.find_free_variables_in_expression(elem, local_vars, free_vars)?;
@@ -329,7 +333,7 @@ impl SemanticAnalyzer {
         &self,
         elements: &[ExpressionNode],
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         for elem in elements {
             self.find_free_variables_in_expression(elem, local_vars, free_vars)?;
@@ -343,7 +347,7 @@ impl SemanticAnalyzer {
         then_expr: &ExpressionNode,
         else_expr: &ExpressionNode,
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         self.find_free_variables_in_expression(cond, local_vars, free_vars)?;
         self.find_free_variables_in_expression(then_expr, local_vars, free_vars)?;
@@ -356,7 +360,7 @@ impl SemanticAnalyzer {
         params: &[Param],
         body: &[StatementNode],
         local_vars: &std::collections::HashSet<String>,
-        free_vars: &mut std::collections::HashMap<String, Type>,
+        free_vars: &mut std::collections::BTreeMap<String, Type>,
     ) -> Result<(), SemanticError> {
         let mut inner_local_vars = local_vars.clone();
         for param in params {

--- a/mux-compiler/src/semantics/imports.rs
+++ b/mux-compiler/src/semantics/imports.rs
@@ -150,7 +150,7 @@ impl SemanticAnalyzer {
         files: &mut Files,
         span: Span,
     ) -> Result<HashMap<String, Symbol>, SemanticError> {
-        let mut module_analyzer = SemanticAnalyzer::new_for_module(resolver.clone());
+        let mut module_analyzer = SemanticAnalyzer::new_with_resolver(resolver.clone());
         module_analyzer.set_current_file(std::path::PathBuf::from(
             module_path.replace('.', "/") + ".mux",
         ));
@@ -340,7 +340,7 @@ impl SemanticAnalyzer {
                 )
             })?;
 
-        let mut submodule_analyzer = SemanticAnalyzer::new_for_module(resolver.clone());
+        let mut submodule_analyzer = SemanticAnalyzer::new_with_resolver(resolver.clone());
         submodule_analyzer.set_current_file(std::path::PathBuf::from(
             submodule_path.replace('.', "/") + ".mux",
         ));

--- a/mux-compiler/src/semantics/mod.rs
+++ b/mux-compiler/src/semantics/mod.rs
@@ -274,32 +274,6 @@ impl SemanticAnalyzer {
         self.current_file = Some(file);
     }
 
-    fn new_for_module(resolver: Rc<RefCell<crate::module_resolver::ModuleResolver>>) -> Self {
-        let symbol_table = SymbolTable::new();
-        Self {
-            symbol_table,
-            current_bounds: std::collections::HashMap::new(),
-            errors: Vec::new(),
-            is_in_static_method: false,
-            current_self_type: None,
-            module_resolver: Some(resolver),
-            imported_symbols: std::collections::BTreeMap::new(),
-            all_module_asts: std::collections::BTreeMap::new(),
-            module_dependencies: Vec::new(),
-            current_file: None,
-            lambda_captures: std::collections::HashMap::new(),
-            current_return_type: None,
-            current_class_type_params: None,
-            fresh_type_var_counter: 0,
-            hoisted_import_spans: HashSet::new(),
-            class_invariants: HashMap::new(),
-            interface_preconditions: HashMap::new(),
-            inherited_preconditions: HashMap::new(),
-            function_preconditions: HashMap::new(),
-            enum_variant_preconditions: HashMap::new(),
-        }
-    }
-
     pub fn symbol_table(&self) -> &SymbolTable {
         &self.symbol_table
     }

--- a/mux-compiler/src/semantics/mod.rs
+++ b/mux-compiler/src/semantics/mod.rs
@@ -74,9 +74,15 @@ pub struct SemanticAnalyzer {
     is_in_static_method: bool,
     pub current_self_type: Option<Type>,
     pub module_resolver: Option<Rc<RefCell<crate::module_resolver::ModuleResolver>>>,
+    /// Symbols exported by each imported module, keyed by module name.
+    /// Ordered: codegen walks it when resolving a class or function that came
+    /// from an import, and the order it finds them in reaches the emitted IR.
     pub imported_symbols:
-        std::collections::HashMap<String, std::collections::HashMap<String, Symbol>>,
-    pub all_module_asts: std::collections::HashMap<String, Vec<AstNode>>,
+        std::collections::BTreeMap<String, std::collections::HashMap<String, Symbol>>,
+    /// Every module's AST, keyed by module name. Ordered, because codegen
+    /// concatenates these to build the compilation unit, so this map's
+    /// iteration order is the order module code is emitted in (issue #344).
+    pub all_module_asts: std::collections::BTreeMap<String, Vec<AstNode>>,
     pub module_dependencies: Vec<String>,
     pub(super) current_file: Option<std::path::PathBuf>, // Track current file for relative imports
     pub lambda_captures: std::collections::HashMap<Span, Vec<(String, Type)>>, // Track captured variables for each lambda
@@ -130,8 +136,8 @@ impl SemanticAnalyzer {
             is_in_static_method: false,
             current_self_type: None,
             module_resolver: None,
-            imported_symbols: std::collections::HashMap::new(),
-            all_module_asts: std::collections::HashMap::new(),
+            imported_symbols: std::collections::BTreeMap::new(),
+            all_module_asts: std::collections::BTreeMap::new(),
             module_dependencies: Vec::new(),
             current_file: None,
             lambda_captures: std::collections::HashMap::new(),
@@ -277,8 +283,8 @@ impl SemanticAnalyzer {
             is_in_static_method: false,
             current_self_type: None,
             module_resolver: Some(resolver),
-            imported_symbols: std::collections::HashMap::new(),
-            all_module_asts: std::collections::HashMap::new(),
+            imported_symbols: std::collections::BTreeMap::new(),
+            all_module_asts: std::collections::BTreeMap::new(),
             module_dependencies: Vec::new(),
             current_file: None,
             lambda_captures: std::collections::HashMap::new(),
@@ -327,11 +333,11 @@ impl SemanticAnalyzer {
 
     pub fn imported_symbols(
         &self,
-    ) -> &std::collections::HashMap<String, std::collections::HashMap<String, Symbol>> {
+    ) -> &std::collections::BTreeMap<String, std::collections::HashMap<String, Symbol>> {
         &self.imported_symbols
     }
 
-    pub fn all_module_asts(&self) -> &std::collections::HashMap<String, Vec<AstNode>> {
+    pub fn all_module_asts(&self) -> &std::collections::BTreeMap<String, Vec<AstNode>> {
         &self.all_module_asts
     }
 

--- a/mux-compiler/tests/cli_integration.rs
+++ b/mux-compiler/tests/cli_integration.rs
@@ -154,18 +154,48 @@ fn build_reports_semantic_error() {
 /// asserted on IR text, so it went unnoticed.
 ///
 /// The program below exercises each path at once: a generic class with methods
-/// to monomorphize, a closure with several captures, and a class whose
-/// invariant binds several fields (their GEPs were emitted in hash order).
+/// to monomorphize, a closure with several captures, a class whose invariant
+/// binds several fields (their GEPs were emitted in hash order), and imports
+/// from two modules - without those the module maps are empty and their
+/// ordering is never tested, so a revert there would pass unnoticed.
 ///
 /// Eight builds rather than two, because the field-order case flipped a coin
 /// per build - four builds missed it often enough to be useless as a gate.
 #[test]
 fn repeated_builds_emit_identical_ir() {
     let dir = unique_tmp_dir("determinism");
+    write_file(
+        &dir,
+        "det_alpha.mux",
+        r#"
+func alpha_one(int n) returns int {
+    return n + 1
+}
+
+func alpha_two(int n) returns int {
+    return n + 2
+}
+"#,
+    );
+    write_file(
+        &dir,
+        "det_beta.mux",
+        r#"
+func beta_one(int n) returns int {
+    return n * 2
+}
+
+func beta_two(int n) returns int {
+    return n * 3
+}
+"#,
+    );
     let src = write_file(
         &dir,
         "determinism.mux",
         r#"
+import det_alpha
+import det_beta
 class Box<T> {
     T value
 
@@ -193,6 +223,11 @@ class Server {
 }
 
 func main() returns void {
+    print(det_alpha.alpha_one(1).to_string())
+    print(det_alpha.alpha_two(1).to_string())
+    print(det_beta.beta_one(2).to_string())
+    print(det_beta.beta_two(2).to_string())
+
     auto s = Server.new()
     print(s.describe())
 

--- a/mux-compiler/tests/cli_integration.rs
+++ b/mux-compiler/tests/cli_integration.rs
@@ -143,3 +143,84 @@ fn build_reports_semantic_error() {
     assert!(!out.stderr.is_empty());
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// Building the same file twice must produce byte-identical LLVM IR.
+///
+/// Codegen walks several maps to decide what to emit and in what order -
+/// function nodes for monomorphization, module ASTs for the compilation unit,
+/// a lambda's captured variables for its environment layout. When those were
+/// `HashMap`s, Rust's per-process hash seed randomization made the emitted IR
+/// differ between back-to-back builds of the same file (issue #344). Nothing
+/// asserted on IR text, so it went unnoticed.
+///
+/// The program below exercises all three paths at once: a generic class with
+/// methods to monomorphize, and a closure with several captures.
+#[test]
+fn repeated_builds_emit_identical_ir() {
+    let dir = unique_tmp_dir("determinism");
+    let src = write_file(
+        &dir,
+        "determinism.mux",
+        r#"
+class Box<T> {
+    T value
+
+    common func from(T val) returns Box<T> {
+        auto b = Box<T>.new()
+        b.value = val
+        return b
+    }
+
+    func get() returns T {
+        return self.value
+    }
+}
+
+func main() returns void {
+    auto a = Box<int>.from(1)
+    auto b = Box<string>.from("two")
+    auto c = Box<bool>.from(true)
+    print(a.get().to_string())
+    print(b.get())
+    print(c.get().to_string())
+
+    auto first = 1
+    auto second = 2
+    auto third = 3
+    auto sum = func() returns int {
+        return first + second + third
+    }
+    print(sum().to_string())
+    return
+}
+"#,
+    );
+    let ir = dir.join("determinism.ll");
+
+    let build_once = || {
+        let out = mux()
+            .arg("build")
+            .arg("--intermediate")
+            .arg(&src)
+            .arg("-o")
+            .arg(dir.join("determinism_bin"))
+            .output()
+            .expect("spawn mux build");
+        assert!(
+            out.status.success(),
+            "build failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        std::fs::read(&ir).expect("intermediate .ll should exist")
+    };
+
+    let first = build_once();
+    for run in 2..=4 {
+        assert!(
+            build_once() == first,
+            "run {run} emitted different IR than run 1; codegen order is not deterministic (issue #344)"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/mux-compiler/tests/cli_integration.rs
+++ b/mux-compiler/tests/cli_integration.rs
@@ -153,8 +153,12 @@ fn build_reports_semantic_error() {
 /// differ between back-to-back builds of the same file (issue #344). Nothing
 /// asserted on IR text, so it went unnoticed.
 ///
-/// The program below exercises all three paths at once: a generic class with
-/// methods to monomorphize, and a closure with several captures.
+/// The program below exercises each path at once: a generic class with methods
+/// to monomorphize, a closure with several captures, and a class whose
+/// invariant binds several fields (their GEPs were emitted in hash order).
+///
+/// Eight builds rather than two, because the field-order case flipped a coin
+/// per build - four builds missed it often enough to be useless as a gate.
 #[test]
 fn repeated_builds_emit_identical_ir() {
     let dir = unique_tmp_dir("determinism");
@@ -176,7 +180,22 @@ class Box<T> {
     }
 }
 
+class Server {
+    string host = "localhost" where { host.length() < 64 }
+    int port = 8080 where { port > 0, port < 65535 }
+    int backlog = 16 where { backlog > 0 }
+
+    func describe() returns string {
+        return self.host + ":" + self.port.to_string()
+    }
+} where {
+    port != 22
+}
+
 func main() returns void {
+    auto s = Server.new()
+    print(s.describe())
+
     auto a = Box<int>.from(1)
     auto b = Box<string>.from("two")
     auto c = Box<bool>.from(true)
@@ -215,7 +234,7 @@ func main() returns void {
     };
 
     let first = build_once();
-    for run in 2..=4 {
+    for run in 2..=8 {
         assert!(
             build_once() == first,
             "run {run} emitted different IR than run 1; codegen order is not deterministic (issue #344)"


### PR DESCRIPTION
Closes #344.

## The problem

Compiling the same file twice produced LLVM IR that differed byte-for-byte -
same functions, same bodies, different order. Codegen walks several maps to
decide what to emit and in what order, and those maps were `HashMap`s, whose
iteration order Rust randomizes per process.

## Wider than reported

#344 identified monomorphized generic methods, via `nested_generics.mux`.
Measuring every program in `test_scripts/` (four builds each, comparing sha256
of `--intermediate` output) found **9 of 115 varying**, in three separate
places:

| map | what it orders | scripts affected |
| --- | --- | --- |
| `function_nodes` | which methods `generate_specialized_methods` monomorphizes, and in what order | the generic-heavy ones #344 reported |
| `all_module_asts` | the order module code is concatenated into the compilation unit | `test_imports`, `test_module_*`, `modglobal_e` |
| a lambda's free variables | the capture list, and so the layout of the closure environment struct | `test_closures`, `where_clauses` |

`imported_symbols` is ordered for the same reason as `all_module_asts`.

The closure one is the least obvious: free variables are collected into a map
and then into a `Vec` that becomes the capture list, so hash order was choosing
an environment struct layout. Self-consistent within a build, so never wrong,
but different every run.

## The fix

All four become `BTreeMap`. **Determinism by construction rather than sorting
at each walk**, so a future `.iter()` cannot quietly reintroduce this - which
matters, since the original bug was exactly a walk nobody noticed was
order-sensitive.

The lookups these maps mostly serve go from O(1) to O(log n) against a few
hundred entries. Not measurable.

## Verification

- **115 of 115** programs now emit identical IR across four builds each, from
  9 varying before.
- **No snapshot changed** and all 115 still run correctly - only ordering
  moved, not behaviour.
- New `repeated_builds_emit_identical_ir` exercises a generic class and a
  multi-capture closure together. I confirmed it fails on reverting any one of
  the three fixes, rather than trusting that it would:

  ```
  run 2 emitted different IR than run 1; codegen order is not deterministic (issue #344)
  ```

- Full `cargo test`, `cargo fmt`, clippy `-D warnings` green.

## Why it matters

Reproducible builds, and the A/B benchmark gate's byte-identical-IR escape
hatch, which #344 was filed from: for generic-heavy files it could read "IR
differs" when nothing had changed. That escape hatch documents a workaround for
this; with this merged the workaround can be revisited.
