### PR TITLE
Prepare the v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-08-09
+
+The enum and generics release. Generic enums work end to end, a class can
+implement the built-in capabilities and key a map, and `map`/`set` are
+hash-backed with insertion-order iteration. Five of the entries below are
+breaking; read the Changed section before upgrading.
+
 ### Added
 - **Generic enums**: `enum Box<T> { Full(T value), Empty }` now works end to
   end - declaration, construction, matching, and use as a field, a parameter or

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "mux-lang"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1222,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "mux-runtime"
 version = "0.5.0"
-source = "git+https://github.com/muxlang/mux-runtime?branch=main#99f4f9a3ab0122170ff1adc5f5c778eed4da108a"
+source = "git+https://github.com/muxlang/mux-runtime?branch=main#256a7d6fd154ed819c877d8e327d74a4b55a77cd"
 dependencies = [
  "chrono",
  "csv",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The Programming Language For Everyone**
 
-[![Version](https://img.shields.io/badge/version-0.6.0-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
+[![Version](https://img.shields.io/badge/version-0.7.0-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-blue.svg?style=flat-square)](https://mux-lang.dev)
 [![Status](https://img.shields.io/badge/status-alpha-orange.svg?style=flat-square)]()
@@ -82,9 +82,11 @@ Choose the method that works best for you:
 ### Option 1: Prebuilt Binaries (Recommended)
 
 The fastest way to get started. No Rust and no LLVM development libraries
-required - but you do need **clang** matching the linked LLVM major (22), since
-Mux calls it to link every program it compiles. The installer runs `mux doctor`
-when it finishes and names anything missing.
+required - but you do need a **C compiler** (any recent `clang` or `gcc`), since
+Mux calls it to link every program it compiles. The version does not have to
+match the linked LLVM: the compiler emits an object file rather than textual IR,
+so `apt-get install clang` or `pacman -S clang` is enough. The installer runs
+`mux doctor` when it finishes and names anything missing.
 
 **Linux & macOS:**
 ```bash
@@ -165,14 +167,16 @@ func main() returns void {
 ## How it works
 
 ```
-.mux --> lexer --> parser --> semantics --> LLVM codegen --> .ll --> clang --> native binary
-                                                                   (links libmux_runtime)
+.mux --> lexer --> parser --> semantics --> LLVM codegen --> .o --> cc --> native binary
+                                                                 (links libmux_runtime)
 ```
 
-The compiler emits LLVM IR and invokes `clang` to produce a native binary that
-links the [runtime](https://github.com/muxlang/mux-runtime) (reference counting,
-strings, collections, stdlib). Use `mux run -i <file.mux>` to view the generated
-IR. The deeper design notes (value representation, monomorphization, the object
+The compiler emits an **object file** and invokes a C compiler to link it
+against the [runtime](https://github.com/muxlang/mux-runtime) (reference
+counting, strings, collections, stdlib). Emitting an object rather than textual
+IR is what frees the install from needing a version-matched clang - the linker
+never parses IR, so `clang`, `cc` or `gcc` all work. Use
+`mux run -i <file.mux>` to view the generated IR. The deeper design notes (value representation, monomorphization, the object
 system, memory model) live in [muxlang/mux-context](https://github.com/muxlang/mux-context/tree/main/docs/design).
 
 ---
@@ -195,7 +199,7 @@ Profiling is done with external tools so it stays decoupled from the compiler an
 
 ⚠️ **Alpha Stage**: Mux is actively being developed. Expect breaking changes and incomplete features as we work toward a stable release.
 
-- **Current Version:** 0.6.0
+- **Current Version:** 0.7.0
 
 ## Versioning
 

--- a/mux-compiler/Cargo.toml
+++ b/mux-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mux-lang"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 default-run = "mux"
 description = "The Mux Programming Language Compiler"


### PR DESCRIPTION
The agent-safe half of the release, per [release-process.md](https://github.com/muxlang/mux-context/blob/main/docs/release-process.md#mux-compiler): changelog, version, README, lockfile. **Tagging and the playground deploy are maintainer-only and are not in this PR** - the commands are at the bottom.

## What is in it

**Changelog.** The `Unreleased` section becomes `[0.7.0] - 2026-08-09`, with a lead paragraph naming this the enum and generics release and pointing at the five breaking entries so nobody upgrades past them by accident.

**Version.** `0.6.0` -> `0.7.0` in `mux-compiler/Cargo.toml`, with the README badge and `Current Version` line to match.

**Runtime pin settled.** `cargo update -p mux-runtime` moved the lock from `99f4f9a` to `256a7d6` (mux-runtime `main` HEAD). Checked the delta before taking it:

```
$ git diff --stat 99f4f9a..256a7d6
 .github/workflows/ci.yml | 12 ++++++------
```

One CI workflow file, no runtime code. So this carries no behavior change - it just stops the tag naming a commit one Dependabot bump behind `main`.

## Also closes #320

That issue's entire condition was "a release contains #318". This one does, so it is actionable now rather than at some later release.

#318 made the compiler emit an **object file** instead of handing clang textual IR. The linker never parses LLVM IR, so it does not have to be a version-matched clang - `clang`, `cc` or `gcc` all work. `mux doctor` has said exactly this since #318 (`main.rs:188`: *"Any recent clang or gcc works; the version does not need to match."*); only the docs were stale.

Two README fixes:
- the prebuilt-install prerequisite no longer demands clang matching LLVM 22
- the pipeline diagram showed `.ll --> clang`, which has been wrong since #318. It is now `.o --> cc`

The **source-build** requirement is deliberately untouched: building the compiler still needs the LLVM 22 development libraries, and a C compiler is still needed either way until #319 bundles a linker.

The website half of #320 (`setup.md`, `quick-start.md`) is on muxlang/mux-website#54, which is already held for this release. Putting it in its own PR would publish the relaxation while the playground still runs 0.6.0.

## Verification

Ran on the bumped tree, after the pin moved:

```
$ mux version
compiler v0.7.0
runtime  v0.5.0+g256a7d6
```

- corpus **142/142**
- valgrind **142/142 clean**
- rc-leak-check clean
- clippy clean, `cargo test` green

## Maintainer steps after this merges

```bash
# 1. tag (from mux-compiler main, after this merges)
git checkout main && git pull
git tag -a v0.7.0 -m "Release v0.7.0"
git push origin v0.7.0
# the Release workflow builds the per-platform tarballs --locked and
# publishes the GitHub release. There is no cargo publish step.

# 2. once the release assets exist, deploy the playground (mux-website-api)
#    edit Dockerfile: ARG MUX_VERSION=0.7.0
fly deploy
```

Then muxlang/mux-website#54 goes green, and can be marked ready and merged.