### PR TITLE
Build the runtime before the release verify job's tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,16 @@ jobs:
       - name: Clippy
         run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
+      # cargo emits only a dependency's rlib, never its staticlib, so neither
+      # the test step nor the build step below produces a libmux_runtime.a.
+      # Any test that compiles a Mux program then fails to link. The
+      # build-artifacts job already builds the runtime explicitly for this
+      # reason; this job did not, and nothing caught it until #365 added
+      # repeated_builds_emit_identical_ir, the first test here to build a
+      # program. See the runtime-resolution notes in AGENTS.md.
+      - name: Build runtime
+        run: cargo build -p mux-runtime --locked
+
       - name: Tests
         run: cargo test --locked
 


### PR DESCRIPTION
Fixes the failed `v0.7.0` Release run ([run 31339632360](https://github.com/muxlang/mux-compiler/actions/runs/31339632360)).

## The failure

```
---- repeated_builds_emit_identical_ir stdout ----
build failed:
Could not locate the mux-runtime library.
```

## Cause

The `Verify Release Commit` job runs:

```yaml
- name: Tests
  run: cargo test --locked
- name: Build
  run: cargo build --locked
```

Neither produces a `libmux_runtime.a`. Cargo emits a dependency's **rlib**, never its **staticlib** - the thing AGENTS.md calls out as the reason `run-checks.sh` and `valgrind-checks.sh` both build `-p mux-runtime` explicitly. So a test that compiles a Mux program has nothing to link against.

## Why v0.6.0 released clean

This has been latent since the job was written. No test in it built a Mux program until #365 added `repeated_builds_emit_identical_ir` - the first one that does. That landed after v0.6.0, so this tag is the first to hit it.

## Scope

I checked every other `cargo test` / `cargo build` call site in both workflows rather than just patching the one that failed:

| Site | Builds the runtime first? |
|---|---|
| `release.yml` **Verify Release Commit** | **no - fixed here** |
| `release.yml` build-artifacts | yes, `-p mux-runtime` per platform |
| `build.yml` Packaged Artifact | yes |
| `build.yml` RC Leak Check | yes, and asserts the archive exists |

This job was the only one missing it.

## Not folded into the release commit

The problem is not version-specific, and a tag-triggered run reads the workflow **from the tagged commit** - so the tag has to be recreated regardless. Keeping it separate means the fix is on `main` for every future release rather than buried in a release-prep diff.

## Retag steps after this merges

No GitHub release was published (the run failed before that step), so moving the tag is safe:

```bash
git checkout main && git pull

# drop the tag that points at the pre-fix commit
git tag -d v0.7.0
git push origin :refs/tags/v0.7.0

# retag main, which now contains the workflow fix
git tag -a v0.7.0 -m "Release v0.7.0"
git push origin v0.7.0
```