### PR TITLE
Print a tuple type the way the parser accepts it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ breaking; read the Changed section before upgrading.
   job already ran on the host and adding roughly 180s to every PR and push.
 
 ### Fixed
+- **A diagnostic naming a tuple prints a type you can write.** Type mismatches
+  reported `list<(string, int)>`, but the parser only accepts a tuple spelled
+  `tuple<A, B>`, so copying the reported type into an annotation failed. Every
+  other composite already printed its parseable form; `tuple` was the exception.
 - **A signature can take more than one `_` parameter.** `func f(int _, string _)`
   reported "Duplicate declaration of '_'". A bare `_` is a hole rather than a
   name - nothing can refer to it, since `_` is not an expression - so it no

--- a/mux-compiler/src/semantics/format.rs
+++ b/mux-compiler/src/semantics/format.rs
@@ -12,7 +12,10 @@ pub fn format_type(t: &Type) -> String {
         Type::List(inner) => format!("list<{}>", format_type(inner)),
         Type::Map(k, v) => format!("map<{}, {}>", format_type(k), format_type(v)),
         Type::Set(inner) => format!("set<{}>", format_type(inner)),
-        Type::Tuple(l, r) => format!("({}, {})", format_type(l), format_type(r)),
+        // Every other composite prints in the form the parser accepts, and a
+        // tuple must too: "(int, string)" is not writable syntax, so a
+        // diagnostic naming that type gave the reader nothing they could type.
+        Type::Tuple(l, r) => format!("tuple<{}, {}>", format_type(l), format_type(r)),
         Type::Optional(inner) => format!("optional<{}>", format_type(inner)),
         Type::Result(ok, err) => format!("result<{}, {}>", format_type(ok), format_type(err)),
         Type::Reference(inner) => format!("&{}", format_type(inner)),

--- a/mux-compiler/tests/format_unit.rs
+++ b/mux-compiler/tests/format_unit.rs
@@ -37,12 +37,15 @@ fn format_collection_and_wrapper_types() {
         "map<int, string>"
     );
     assert_eq!(format_type(&Type::Set(b(int()))), "set<int>");
+    // Spelled the way the parser accepts it, like every other composite above.
+    // "(int, bool)" is not writable syntax, so a diagnostic naming that type
+    // handed the reader something they could not type back.
     assert_eq!(
         format_type(&Type::Tuple(
             b(int()),
             b(Type::Primitive(PrimitiveType::Bool))
         )),
-        "(int, bool)"
+        "tuple<int, bool>"
     );
     assert_eq!(format_type(&Type::Optional(b(int()))), "optional<int>");
     assert_eq!(


### PR DESCRIPTION
A one-line diagnostics fix, found while auditing the website's collection method tables against the compiler for the v0.7.0 docs sweep.

## The problem

`format_type` rendered `Type::Tuple` as `(int, bool)`. That is not writable syntax - the parser only accepts a tuple as `tuple<A, B>` (`parser/mod.rs:1937` whitelists `list|map|set|tuple`). So the compiler reported a type you could not type back:

```mux
auto v = m.get_pairs()
string s = v
// before: Type mismatch: expected string, got list<(string, int)>
// after:  Type mismatch: expected string, got list<tuple<string, int>>
```

Copying `list<(string, int)>` into an annotation fails with 4 errors. The message this appears in most often is a type mismatch, where copying the reported type into a declaration is the obvious next move - so the old spelling led straight into a wall.

Every other composite already printed its parseable form (`list<T>`, `map<K, V>`, `set<T>`, `optional<T>`, `result<O, E>`). `Tuple` was the only exception.

## How it surfaced

The website documents `map.get_pairs()` as returning `list<tuple<K, V>>`. That is correct and compiles - the compiler was the one disagreeing with itself.

## Blast radius

**No insta snapshot moved.** That is the useful signal here: it means no error message anywhere in the test corpus currently prints a tuple type, so nothing user-visible changes except the case above. The only assertion pinning the old spelling was a hand-written one in `format_unit.rs`, updated with a comment explaining why.

Corpus 142/142, clippy clean, `cargo test` green.