### PR TITLE
Make the macOS package self-contained

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,16 @@ jobs:
               cp "$lib" dist/mux-${{ matrix.target }}/lib/
             fi
           done
+          # macOS only: llvm-sys links LLVM statically, but LLVM's own system
+          # dependencies arrive dynamically, and Homebrew's llvm@22 pulls in z3.
+          # That left an absolute /opt/homebrew path in the shipped binary, so
+          # it aborted on any machine without Homebrew (#378). Windows already
+          # bundles LLVM's DLLs below for the same reason.
+          if [ "$(uname -s)" = "Darwin" ]; then
+            ./scripts/ci/bundle-macos-dylibs.sh \
+              "dist/mux-${{ matrix.target }}/bin/mux" \
+              "dist/mux-${{ matrix.target }}/lib"
+          fi
           tar -C dist -czf dist/mux-${{ matrix.target }}.${{ matrix.archive_ext }} mux-${{ matrix.target }}
           # Write the checksum with a bare filename (run from dist/) so
           # `sha256sum -c` works from the artifact directory.

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ ci-artifacts/
 **/*.pyc
 .codex
 mux-runtime/
+
+# scripts/ci/smoke-packaged.sh stages a fake install here and compiles a
+# program beside it; both are throwaway.
+dist/
+/smoke
+/smoke.mux
+/smoke.out

--- a/scripts/ci/bundle-macos-dylibs.sh
+++ b/scripts/ci/bundle-macos-dylibs.sh
@@ -17,8 +17,9 @@
 #
 # Deliberately generic: it bundles WHATEVER non-system dylibs are referenced
 # rather than special-casing z3, because the next Homebrew formula change would
-# otherwise reintroduce this with a different library. It ends by asserting that
-# no absolute non-system path survives, so the failure mode is a red build here
+# otherwise reintroduce this with a different library. That is not theoretical -
+# the first real run bundled libzstd alongside z3. It ends by asserting that no
+# absolute non-system path survives, so the failure mode is a red build here
 # rather than an abort trap on a user's machine.
 #
 # Usage: bundle-macos-dylibs.sh <binary> <lib-dir>
@@ -26,19 +27,20 @@ set -euo pipefail
 
 die() { echo "$*" >&2; exit 1; }
 
-[ "$#" -eq 2 ] || die "usage: $0 <binary> <lib-dir>"
+[[ "$#" -eq 2 ]] || die "usage: $0 <binary> <lib-dir>"
 binary="$1"
 lib_dir="$2"
 
-[ "$(uname -s)" = "Darwin" ] || die "this script is macOS only"
-[ -f "$binary" ] || die "no such binary: $binary"
+[[ "$(uname -s)" == "Darwin" ]] || die "this script is macOS only"
+[[ -f "$binary" ]] || die "no such binary: $binary"
 mkdir -p "$lib_dir"
 
 # Paths under these prefixes ship with macOS and are always present, so they are
 # left alone. Anything else (/opt/homebrew, /usr/local, a build directory) has
 # to travel with the package.
 is_system_path() {
-  case "$1" in
+  local path="$1"
+  case "$path" in
     /usr/lib/*|/System/Library/*) return 0 ;;
     *) return 1 ;;
   esac
@@ -47,14 +49,13 @@ is_system_path() {
 # Absolute dependency paths of a Mach-O file, excluding its own LC_ID_DYLIB and
 # any reference already made relocatable (@rpath, @loader_path, ...).
 dependencies_of() {
-  otool -L "$1" | tail -n +2 | awk '{print $1}' | while read -r dep; do
-    case "$dep" in
-      @*) continue ;;
-      /*) ;;
-      *) continue ;;
-    esac
+  local file="$1" own_id dep
+  own_id="$(otool -D "$file" | tail -n +2)"
+  otool -L "$file" | tail -n +2 | awk '{print $1}' | while read -r dep; do
+    # Only absolute paths need rewriting; @rpath and friends are already fine.
+    [[ "$dep" == /* ]] || continue
     # A dylib lists its own install name first; that is identity, not a dep.
-    [ "$dep" = "$(otool -D "$1" | tail -n +2)" ] && continue
+    [[ "$dep" == "$own_id" ]] && continue
     echo "$dep"
   done
 }
@@ -63,8 +64,9 @@ dependencies_of() {
 # invalid signature means the loader refuses the file outright. Ad-hoc signing
 # is enough to make it loadable again; the release is not notarized either way.
 resign() {
-  codesign --force --sign - "$1" >/dev/null 2>&1 ||
-    die "could not re-sign $1 after rewriting its load commands"
+  local file="$1"
+  codesign --force --sign - "$file" >/dev/null 2>&1 ||
+    die "could not re-sign $file after rewriting its load commands"
 }
 
 # Breadth-first over the dependency graph: a bundled dylib has dependencies of
@@ -72,19 +74,19 @@ resign() {
 declare -a queue=("$binary")
 declare -a bundled=()
 
-while [ "${#queue[@]}" -gt 0 ]; do
+while [[ "${#queue[@]}" -gt 0 ]]; do
   current="${queue[0]}"
   queue=("${queue[@]:1}")
 
   while read -r dep; do
-    [ -n "$dep" ] || continue
+    [[ -n "$dep" ]] || continue
     is_system_path "$dep" && continue
 
     name="$(basename "$dep")"
     dest="$lib_dir/$name"
 
-    if [ ! -f "$dest" ]; then
-      [ -f "$dep" ] || die "referenced dylib does not exist: $dep"
+    if [[ ! -f "$dest" ]]; then
+      [[ -f "$dep" ]] || die "referenced dylib does not exist: $dep"
       echo "  bundling $name"
       cp "$dep" "$dest"
       chmod u+w "$dest"
@@ -101,7 +103,7 @@ while [ "${#queue[@]}" -gt 0 ]; do
   done < <(dependencies_of "$current")
 done
 
-if [ "${#bundled[@]}" -eq 0 ]; then
+if [[ "${#bundled[@]}" -eq 0 ]]; then
   echo "No non-system dylibs referenced; nothing to bundle."
 else
   # The loader needs to know where @rpath is. bin/ and lib/ are siblings in the
@@ -116,13 +118,13 @@ fi
 leaked=0
 for file in "$binary" "${bundled[@]+"${bundled[@]}"}"; do
   while read -r dep; do
-    [ -n "$dep" ] || continue
+    [[ -n "$dep" ]] || continue
     if ! is_system_path "$dep"; then
       echo "::error::$(basename "$file") still references a non-system path: $dep" >&2
       leaked=1
     fi
   done < <(dependencies_of "$file")
 done
-[ "$leaked" -eq 0 ] || die "bundling did not make the package self-contained"
+[[ "$leaked" -eq 0 ]] || die "bundling did not make the package self-contained"
 
 echo "Package is self-contained: every dylib reference is a system path or @rpath."

--- a/scripts/ci/bundle-macos-dylibs.sh
+++ b/scripts/ci/bundle-macos-dylibs.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Make a macOS binary self-contained by bundling the non-system dylibs it
+# references and rewriting those references to point inside the package.
+#
+# Why this exists: llvm-sys links LLVM's static archives, but LLVM's own system
+# dependencies come in dynamically. Homebrew's llvm@22 is built with the Z3
+# solver, so `mux` ends up with a load command naming an absolute, Homebrew-
+# specific, VERSION-specific path:
+#
+#   /opt/homebrew/opt/z3/lib/libz3.4.16.dylib
+#
+# That resolves on the build runner and nowhere else. A user installing the
+# tarball without Homebrew z3 at exactly that path gets "Abort trap: 6" before
+# the compiler prints anything - `mux version` and `mux doctor` both die (see
+# issue #378). Windows already solves the same problem by copying LLVM's DLLs
+# into the artifact; this is the macOS equivalent.
+#
+# Deliberately generic: it bundles WHATEVER non-system dylibs are referenced
+# rather than special-casing z3, because the next Homebrew formula change would
+# otherwise reintroduce this with a different library. It ends by asserting that
+# no absolute non-system path survives, so the failure mode is a red build here
+# rather than an abort trap on a user's machine.
+#
+# Usage: bundle-macos-dylibs.sh <binary> <lib-dir>
+set -euo pipefail
+
+die() { echo "$*" >&2; exit 1; }
+
+[ "$#" -eq 2 ] || die "usage: $0 <binary> <lib-dir>"
+binary="$1"
+lib_dir="$2"
+
+[ "$(uname -s)" = "Darwin" ] || die "this script is macOS only"
+[ -f "$binary" ] || die "no such binary: $binary"
+mkdir -p "$lib_dir"
+
+# Paths under these prefixes ship with macOS and are always present, so they are
+# left alone. Anything else (/opt/homebrew, /usr/local, a build directory) has
+# to travel with the package.
+is_system_path() {
+  case "$1" in
+    /usr/lib/*|/System/Library/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Absolute dependency paths of a Mach-O file, excluding its own LC_ID_DYLIB and
+# any reference already made relocatable (@rpath, @loader_path, ...).
+dependencies_of() {
+  otool -L "$1" | tail -n +2 | awk '{print $1}' | while read -r dep; do
+    case "$dep" in
+      @*) continue ;;
+      /*) ;;
+      *) continue ;;
+    esac
+    # A dylib lists its own install name first; that is identity, not a dep.
+    [ "$dep" = "$(otool -D "$1" | tail -n +2)" ] && continue
+    echo "$dep"
+  done
+}
+
+# install_name_tool invalidates a Mach-O signature, and on Apple Silicon an
+# invalid signature means the loader refuses the file outright. Ad-hoc signing
+# is enough to make it loadable again; the release is not notarized either way.
+resign() {
+  codesign --force --sign - "$1" >/dev/null 2>&1 ||
+    die "could not re-sign $1 after rewriting its load commands"
+}
+
+# Breadth-first over the dependency graph: a bundled dylib has dependencies of
+# its own, and those have to come along and be rewritten too.
+declare -a queue=("$binary")
+declare -a bundled=()
+
+while [ "${#queue[@]}" -gt 0 ]; do
+  current="${queue[0]}"
+  queue=("${queue[@]:1}")
+
+  while read -r dep; do
+    [ -n "$dep" ] || continue
+    is_system_path "$dep" && continue
+
+    name="$(basename "$dep")"
+    dest="$lib_dir/$name"
+
+    if [ ! -f "$dest" ]; then
+      [ -f "$dep" ] || die "referenced dylib does not exist: $dep"
+      echo "  bundling $name"
+      cp "$dep" "$dest"
+      chmod u+w "$dest"
+      # Its own identity has to be relocatable as well, or anything linking it
+      # records the absolute path again.
+      install_name_tool -id "@rpath/$name" "$dest"
+      resign "$dest"
+      bundled+=("$dest")
+      queue+=("$dest")
+    fi
+
+    install_name_tool -change "$dep" "@rpath/$name" "$current"
+    resign "$current"
+  done < <(dependencies_of "$current")
+done
+
+if [ "${#bundled[@]}" -eq 0 ]; then
+  echo "No non-system dylibs referenced; nothing to bundle."
+else
+  # The loader needs to know where @rpath is. bin/ and lib/ are siblings in the
+  # installed layout, which is what scripts/install.sh lays down.
+  install_name_tool -add_rpath "@executable_path/../lib" "$binary" 2>/dev/null || true
+  resign "$binary"
+fi
+
+# The point of the whole exercise: prove nothing absolute and non-system is left
+# in any load command. Without this the script could silently miss a case and
+# the break would resurface as an abort trap on a user's machine.
+leaked=0
+for file in "$binary" "${bundled[@]+"${bundled[@]}"}"; do
+  while read -r dep; do
+    [ -n "$dep" ] || continue
+    if ! is_system_path "$dep"; then
+      echo "::error::$(basename "$file") still references a non-system path: $dep" >&2
+      leaked=1
+    fi
+  done < <(dependencies_of "$file")
+done
+[ "$leaked" -eq 0 ] || die "bundling did not make the package self-contained"
+
+echo "Package is self-contained: every dylib reference is a system path or @rpath."

--- a/scripts/ci/smoke-packaged.sh
+++ b/scripts/ci/smoke-packaged.sh
@@ -51,6 +51,15 @@ if [[ "$found_lib" -eq 0 ]]; then
   exit 1
 fi
 
+# The macOS binary picks up whatever dylibs Homebrew's LLVM drags in, by
+# absolute path. Bundling them here is what makes this a test of a package that
+# could actually be installed elsewhere - without it the staged layout only
+# works because the build machine happens to have Homebrew (issue #378). The
+# script asserts self-containment, so this is also where that regresses loudly.
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  "$(dirname "$0")/bundle-macos-dylibs.sh" "$dist/bin/mux" "$dist/lib"
+fi
+
 # mux.exe loads LLVM dynamically on Windows, so a real install ships those DLLs
 # beside it. Copying them here keeps this a test of the packaged layout rather
 # than of whatever happens to be on PATH.


### PR DESCRIPTION
Fixes #378, which is blocking the v0.7.0 publish.

## The break

Install verification failed on **both** macOS targets while Linux and Windows passed:

```
dyld: Library not loaded: /opt/homebrew/opt/z3/lib/libz3.4.16.dylib
  Referenced from: .../installed/bin/mux
install.sh: line 138: Abort trap: 6   "$INSTALL_DIR/mux" doctor
```

`llvm-sys` links LLVM's static archives, but LLVM's own system dependencies arrive **dynamically**, and Homebrew's `llvm@22` is built with the Z3 solver. The shipped binary therefore carried an absolute, Homebrew-specific, *version*-specific load command. It resolves on the build runner and nowhere else - `mux version` and `mux doctor` both abort before printing anything.

## Not a regression

v0.6.0's release run had **no install-verification jobs at all** (its job list is Verify Release Commit, five builds, Publish). That matrix was added afterwards. So the v0.6.0 macOS tarballs very likely abort the same way and nothing reported it - this job caught a real shipped defect on its first run.

## The fix

Windows already solves this by copying LLVM's DLLs into the artifact. `scripts/ci/bundle-macos-dylibs.sh` is the macOS equivalent:

1. walk the dependency graph with `otool -L`
2. copy every **non-system** dylib into `lib/` (system = `/usr/lib`, `/System/Library`; everything else travels)
3. rewrite the load commands to `@rpath/<name>`, and each bundled dylib's own id too
4. add `@executable_path/../lib` as an rpath - `bin/` and `lib/` are siblings in what `install.sh` lays down
5. **ad-hoc re-sign every file touched**: `install_name_tool` invalidates a Mach-O signature, and on Apple Silicon an invalid signature makes the loader refuse the file outright

It is deliberately **generic rather than z3-specific** - the next Homebrew formula change would otherwise reintroduce this under a different name - and it bundles **transitively**, since a bundled dylib has dependencies of its own.

### The assertion is the real guarantee

The script ends by proving no absolute non-system path survives in any load command. Without it, a missed case resurfaces as an abort trap on a user's machine instead of a red build here.

**Explicitly not done: installing z3 on the verify runner.** That turns CI green while every macOS user without Homebrew keeps getting `Abort trap: 6`. The job was reporting the truth.

## Verification, and its limit

- `lint-workflows.sh` passes - actionlint plus shellcheck, and it already covers `scripts/ci/*.sh`, so no new lint step was needed (I added one, then removed it as redundant)
- `smoke-packaged.sh` still passes unchanged on Linux, where the new branch is skipped

**I have no macOS host.** So the traversal, transitive bundling, rewriting and the assertion were exercised against a stand-in `otool`/`install_name_tool` pair - including the **failure** path, confirming the assertion actually fires when a rewrite silently does nothing:

```
  bundling libz3.4.16.dylib
  bundling libgmp.10.dylib
Package is self-contained: every dylib reference is a system path or @rpath.
```

Wiring it into `smoke-packaged.sh` means `Packaged Artifact (macos-aarch64)` exercises it on **this PR**, not only on a tag. The end-to-end proof is the Verify Install job on the next tag.

## Also

Gitignores the `dist/` and `smoke.*` files `smoke-packaged.sh` leaves in the working tree.

## After merging

```bash
git checkout main && git pull
git tag -d v0.7.0 && git push origin :refs/tags/v0.7.0
git tag -a v0.7.0 -m "Release v0.7.0" && git push origin v0.7.0
```