### PR TITLE
Give the shipped runtime dylib a relocatable install name

### DIFF
--- a/scripts/ci/bundle-macos-dylibs.sh
+++ b/scripts/ci/bundle-macos-dylibs.sh
@@ -103,6 +103,24 @@ while [[ "${#queue[@]}" -gt 0 ]]; do
   done < <(dependencies_of "$current")
 done
 
+# Every dylib we SHIP has to have a relocatable install name, not only the ones
+# pulled in above. libmux_runtime.dylib is the case that matters: cargo stamps a
+# cdylib's install name with its own build path
+# (target/release/deps/libmux_runtime-<hash>.dylib), and a program records the
+# install name of what it linked against - not the path the linker found it at.
+# So every program `mux` compiled on macOS pointed at a build tree that exists
+# on exactly one machine, and aborted anywhere else. The -Wl,-rpath the compiler
+# already passes cannot help while the recorded name is absolute.
+shopt -s nullglob
+for shipped in "$lib_dir"/*.dylib; do
+  current_id="$(otool -D "$shipped" | tail -n +2)"
+  [[ "$current_id" == /* ]] || continue
+  echo "  normalizing install name of $(basename "$shipped")"
+  install_name_tool -id "@rpath/$(basename "$shipped")" "$shipped"
+  resign "$shipped"
+done
+shopt -u nullglob
+
 if [[ "${#bundled[@]}" -eq 0 ]]; then
   echo "No non-system dylibs referenced; nothing to bundle."
 else
@@ -116,7 +134,8 @@ fi
 # in any load command. Without this the script could silently miss a case and
 # the break would resurface as an abort trap on a user's machine.
 leaked=0
-for file in "$binary" "${bundled[@]+"${bundled[@]}"}"; do
+shopt -s nullglob
+for file in "$binary" "$lib_dir"/*.dylib; do
   while read -r dep; do
     [[ -n "$dep" ]] || continue
     if ! is_system_path "$dep"; then
@@ -124,7 +143,19 @@ for file in "$binary" "${bundled[@]+"${bundled[@]}"}"; do
       leaked=1
     fi
   done < <(dependencies_of "$file")
+
+  # An absolute install name is the other half of the same failure: it is what a
+  # program linking this dylib records, so it breaks the program rather than
+  # this file. Checking it here is what makes the packaged-artifact job on a PR
+  # catch it, instead of only the install verification on a tag.
+  [[ "$file" == "$binary" ]] && continue
+  shipped_id="$(otool -D "$file" | tail -n +2)"
+  if [[ "$shipped_id" == /* ]]; then
+    echo "::error::$(basename "$file") has an absolute install name: $shipped_id" >&2
+    leaked=1
+  fi
 done
+shopt -u nullglob
 [[ "$leaked" -eq 0 ]] || die "bundling did not make the package self-contained"
 
 echo "Package is self-contained: every dylib reference is a system path or @rpath."


### PR DESCRIPTION
Follow-on to #379, which fixed the first half of this. Blocks the v0.7.0 publish.

## What changed since #379

The release got **further** and failed **differently**. `install.sh` now succeeds and `mux` itself runs - the z3 problem is gone. The failure moved to the first program the compiler builds:

```
dyld: Library not loaded: .../target/release/deps/libmux_runtime-138dbdaba92810d3.dylib
  Referenced from: .../smoke        <- the compiled Mux program, not mux
```

Step-by-step, `Install with scripts/install.sh` went from `failure` to `success`; `Compile and run programs with the installed compiler` is the new failure.

## Cause

Same class as #378, one layer down. Cargo stamps a cdylib's install name with its own build path, and **a program records the install name of what it linked against**, not the path the linker found it at. So every program `mux` compiled on macOS pointed into a build tree that exists on exactly one machine.

The `-Wl,-rpath,<lib_dir>` the compiler already passes cannot help while the recorded name is absolute - the rpath is only consulted for `@rpath/...` names.

Pre-existing, and invisible from the build machine for exactly the reason z3 was: there, the path resolves.

## Fix

`bundle-macos-dylibs.sh` now normalizes the install name of **every dylib in the shipped `lib/`**, not only the ones it pulled in as dependencies of the compiler binary. `libmux_runtime.dylib` is the case that matters and the earlier pass could never have caught it: nothing links it *into* `mux`, so it was never on the dependency walk.

## The detection gap this closes

The self-containment assertion now checks install names too, not just dependency references. That matters more than the fix itself:

- **before:** an absolute install name was only observable in the release's install-verification job, i.e. on a tag, after a full build
- **after:** it fails `Packaged Artifact (macos-aarch64)` on a PR

`Packaged Artifact` passes on macOS today only because it runs beside the build tree it compiled in - the same blind spot that let both of these ship.

## Verification

shellcheck and `bash -n` clean. Exercised against the stand-in `otool`/`install_name_tool` harness in both directions:

```
  bundling libz3.4.16.dylib
  normalizing install name of libmux_runtime.dylib
Package is self-contained: every dylib reference is a system path or @rpath.
```

and with the `-id` rewrite silently doing nothing, to prove the assertion fires rather than passing a broken package:

```
::error::libmux_runtime.dylib has an absolute install name: /build/target/release/deps/libmux_runtime-138dbd.dylib
bundling did not make the package self-contained
```