### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-08-14
 
 ### Added
 - **Typed accessors on `Json`**: `as_string`, `as_int`, `as_float`, `as_bool`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "mux-lang"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1222,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "mux-runtime"
 version = "0.5.0"
-source = "git+https://github.com/muxlang/mux-runtime?branch=main#755f4bbb4b3e72bd35bb1663b115a061f9aadd4e"
+source = "git+https://github.com/muxlang/mux-runtime?branch=main#98bf49ecd02d844c9dddede90afe1d1883884859"
 dependencies = [
  "chrono",
  "csv",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The Programming Language For Everyone**
 
-[![Version](https://img.shields.io/badge/version-0.8.1-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
+[![Version](https://img.shields.io/badge/version-0.9.0-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-blue.svg?style=flat-square)](https://mux-lang.dev)
 [![Status](https://img.shields.io/badge/status-alpha-orange.svg?style=flat-square)]()
@@ -199,7 +199,7 @@ Profiling is done with external tools so it stays decoupled from the compiler an
 
 ⚠️ **Alpha Stage**: Mux is actively being developed. Expect breaking changes and incomplete features as we work toward a stable release.
 
-- **Current Version:** 0.8.1
+- **Current Version:** 0.9.0
 
 ## Versioning
 

--- a/mux-compiler/Cargo.toml
+++ b/mux-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mux-lang"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 default-run = "mux"
 description = "The Mux Programming Language Compiler"


### PR DESCRIPTION
Prepares the 0.9.0 release. No code changes - version, changelog, README, lockfile, and the runtime pin.

## The runtime pin is the part worth reviewing

`Cargo.lock` named `755f4bb`, **one commit behind mux-runtime main**. The socket copy fix (muxlang/mux-runtime#58, `98bf49e`) was merged but was not in anything the compiler would build.

Nothing would have caught this: merging a runtime PR does not move the pin, and CI stays green throughout, because green only means the compiler works against whatever it is currently pinned to. Releasing without this step ships a compiler linked against a runtime that still returns a null handle from every socket copy.

`mux version` now reports:

```
compiler v0.9.0
runtime  v0.5.0+g98bf49e
```

## Why minor, not patch

New language surface: string decomposition and slicing, uninitialized declarations, module-qualified types in type positions, JSON accessors, trailing commas in call argument lists, multi-line expressions.

Three changes can alter what an existing program does:
- `length` counts **characters**, not bytes
- JSON integers stay integers (`{"n":42}` no longer re-serializes as `42.0`)
- a bare class name under a namespace import (`import std.net` then `TcpListener.bind`) is now an error rather than an internal compiler error

## Not done here

Tagging and the playground deploy are maintainer steps (see [release-process.md](https://github.com/muxlang/mux-context/blob/main/docs/release-process.md#mux-compiler)). `ARG MUX_VERSION` in mux-website-api follows separately and is what unblocks muxlang/mux-website#56.