### PR TITLE
Refresh a comment that still says #391 is unfixed

### DIFF
--- a/mux-compiler/src/codegen/classes.rs
+++ b/mux-compiler/src/codegen/classes.rs
@@ -647,12 +647,15 @@ impl<'a> CodeGenerator<'a> {
     pub(super) fn generate_interface_type(&mut self, name: &str) -> Result<(), String> {
         // generate LLVM struct for interface: { *mut vtable, field1, field2, ... }
         // for simplicity, vtable is struct of void* function pointers
-        // A class can name an interface that was never imported: importing a
-        // type does not pull in the interfaces it implements, so
-        // `import std.dsa.graph.Graph` alone leaves `Collection` unknown here.
-        // That is muxlang/mux-compiler#391 and the import side is the real fix;
-        // until then this must not read as a compiler crash, because the user
-        // can act on it - the missing import is theirs to add.
+        // A class can name an interface that is not in scope. Importing a type
+        // now brings its interfaces with it, and semantics reports what the
+        // module cannot supply before codegen runs (#391), so reaching here
+        // means both of those missed something.
+        //
+        // It stays a message the user can act on rather than an assertion. The
+        // failure it guards is a missing import, which is theirs to fix, and
+        // reporting it as a compiler crash sends them to file a bug about their
+        // own program - which is exactly what #391 was.
         let symbol = self.analyzer.all_symbols().get(name).ok_or_else(|| {
             format!(
                 "interface '{name}' is implemented by a type in use here but was never imported.\n\


### PR DESCRIPTION
Found while sweeping for stale references to issues this release closed.

The comment on `generate_interface_type` said importing the interface side was "the real fix" and that this fallback stood **"until then"**. That shipped in 0.9.0, so the note describes a compiler that no longer exists.

The fallback itself stays, and the comment now says why: an import brings a type's interfaces with it, and semantics reports what a module genuinely cannot supply before codegen runs, so reaching this point means both of those missed something. It should still be a message the user can act on rather than an assertion - the failure it guards is a missing import, which is theirs to fix, and reporting it as a compiler crash is precisely what #391 was.

Comment-only; no behavior change.