### PR TITLE
Pin the runtime that has mux_json_field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,7 @@ dependencies = [
 [[package]]
 name = "mux-runtime"
 version = "0.5.0"
-source = "git+https://github.com/muxlang/mux-runtime?branch=main#98bf49ecd02d844c9dddede90afe1d1883884859"
+source = "git+https://github.com/muxlang/mux-runtime?branch=main#c7e79759985e01c753e7ce2d084deeffca711ce4"
 dependencies = [
  "chrono",
  "csv",


### PR DESCRIPTION
Moves `Cargo.lock` from `98bf49e` to `c7e7975` - the merge of muxlang/mux-runtime#59, which adds `mux_json_field`.

## Why this is its own PR

Merging a runtime PR **does not move this pin**. The compiler keeps building whatever the lockfile names, so compiler CI goes green either way - which is precisely how the socket fix (mux-runtime#58) sat merged-but-unshipped earlier in 0.9.0 with every check passing.

Splitting the bump out means the first build that actually contains the new symbol is one CI can speak to, instead of burying a lockfile change inside the large feature PR that depends on it.

## Verification

```
$ mux version
compiler v0.9.0
runtime  v0.5.0+gc7e7975
```

Full `cargo test` passes against the new pin. No source changes - lockfile only.

## What follows

Typed deserialization (#404) emits calls to `mux_json_field`, so it lands on top of this pin.