### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,81 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-08-20
+
+### Changed
+
+- **BREAKING: typed accessors return `result`, not `optional`.** `Json.as_int`,
+  `as_string`, `as_float`, `as_bool`, `as_list`, `as_map` and every
+  `SqlValue.as_*` now answer `result<T, string>`, and the error names what was
+  actually there:
+
+  ```
+  expected an int, found a string
+  ```
+
+  `none` left a reader unable to tell a string from a null from something else -
+  exactly the information needed when a document is not the shape you expected.
+  The prompting case was a config with `"port": "8080"` quoted.
+
+  On the SQL side the message already existed and was being discarded with
+  `.ok()`, and the declaration said `result` while the runtime returned
+  `optional`, so `ok`/`err` had only ever worked by coincidence of
+  representation.
+
+  **Migration:** `match v.as_int() { some(n) ... none ... }` becomes
+  `match v.as_int() { ok(n) ... err(e) ... }` (#404).
+
+### Added
+
+- **Parse a document straight into a class.** Every class is given
+  `from_json`, `list_from_json` and `list_from_csv`, synthesized the way `new`
+  is:
+
+  ```mux
+  class Config { int port  string host  optional<string> note }
+
+  match Config.from_json(text) {
+      ok(cfg) { print(cfg.host) }
+      err(e)  { print(e) }        // field 'port': expected an int
+  }
+  ```
+
+  The shape check happens once at the boundary instead of an `as_int()` at every
+  field. `Json` exists because Mux containers are homogeneous - `{"port": 8080,
+  "host": "localhost"}` is a type error as a Mux map - and this removes the need
+  to work at that level for any document whose shape can be described.
+
+  A missing required field is an error naming it; `optional<T>` accepts absent
+  **or** explicit `null`, both meaning `none`; a wrong kind names the field and
+  the type expected; fields the class does not declare are ignored, so a server
+  adding one does not break a reader.
+
+  Nested classes, `list<T>` of primitives and of classes, and `optional<T>` are
+  supported. An error inside a nested class names the field that was wrong, not
+  the one containing it. `Json` and `list<Json>` are the escape hatch for what
+  cannot be declared - `[1, "two", true]` is legal JSON that no Mux list holds.
+
+  CSV differs because a cell is always text: an `int` column is *parsed* rather
+  than type-checked, so a column can only be a primitive or an optional of one,
+  and `optional` there means the **column** may be missing from the header.
+  There is deliberately no singular `from_csv` - a CSV document is a table
+  (#404).
+
+- **`to_string` on `Json` and `Csv`.** The total render every other type has.
+  `stringify` stays as the configurable form: it takes an indent and returns a
+  `result`, so it cannot satisfy `Stringable`. Rendering a document no longer
+  needs a four-line `match` (#405).
+
+### Fixed
+
+- **A class field of an opaque stdlib type is no longer an internal compiler
+  error.** `class Holder { Json raw }` and `class Server { TcpListener listener }`
+  failed to compile: field initialization constructed any named type, and these
+  are runtime-registered handles with no Mux layout. They now start null, which
+  is what an uninitialized `string` field already does. This is what allows a
+  bare `Json` field as the deserialization escape hatch (#408).
+
 ## [0.9.0] - 2026-08-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "mux-lang"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The Programming Language For Everyone**
 
-[![Version](https://img.shields.io/badge/version-0.9.0-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
+[![Version](https://img.shields.io/badge/version-0.10.0-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-blue.svg?style=flat-square)](https://mux-lang.dev)
 [![Status](https://img.shields.io/badge/status-alpha-orange.svg?style=flat-square)]()
@@ -199,7 +199,7 @@ Profiling is done with external tools so it stays decoupled from the compiler an
 
 ⚠️ **Alpha Stage**: Mux is actively being developed. Expect breaking changes and incomplete features as we work toward a stable release.
 
-- **Current Version:** 0.9.0
+- **Current Version:** 0.10.0
 
 ## Versioning
 

--- a/mux-compiler/Cargo.toml
+++ b/mux-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mux-lang"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 default-run = "mux"
 description = "The Mux Programming Language Compiler"


### PR DESCRIPTION
Prepares 0.10.0. Version, changelog, README, lockfile - no code changes.

## The changelog did not exist

None of the PRs since 0.9.0 added an entry, so this writes the whole section rather than rolling up an `[Unreleased]` heading. Worth noting for next time: the runtime keeps `[Unreleased]` current as part of each change (22 entries there), and the compiler did not.

## Breaking change, listed first

`Json.as_*` and every `SqlValue.as_*` return `result<T, string>` instead of `optional<T>`:

```mux
match v.as_int() { some(n) ... none ... }   // before
match v.as_int() { ok(n) ... err(e) ... }   // after
```

The error names what was there - `expected an int, found a string` - which is what a bare `none` threw away. On the SQL side the message was already being computed and discarded with `.ok()`, and the declaration said `result` while the runtime returned `optional`, so `ok`/`err` had only ever worked by coincidence of representation.

## Also in this release

- **Typed deserialization** - `Config.from_json(text)`, `list_from_json`, `list_from_csv`, with nesting, lists, optionals, and `Json` as the escape hatch (#404)
- **`to_string` on `Json` and `Csv`** (#405)
- **A class field of an opaque stdlib type** (`Json`, `TcpListener`) is no longer an internal compiler error (#408)

## Verification

Runtime pin is already current at `3436157` (muxlang/mux-runtime#61):

```
compiler v0.10.0
runtime  v0.5.0+g3436157
```

All eight feature scripts from this work pass on merged `main`, with `MUX_RUNTIME_LIB` unset so the pinned runtime is what is actually exercised.

## After this

Tag `v0.10.0`, then `ARG MUX_VERSION` in mux-website-api and `fly deploy` - which unblocks muxlang/mux-website#59 and muxlang/mux-examples#5, both currently red only because they compile against the released compiler.