### PR TITLE
Release 0.10.1: report the runtime the compiler is built against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-08-21
+
+### Fixed
+
+- **`mux version` reports the runtime it is actually built against.** The 0.10.0
+  pin named the commit before mux-runtime closed its changelog at 0.6.0, so the
+  binary said `runtime v0.5.0` while the runtime repo said 0.6.0. The pinned
+  code was identical - that commit changed only docs and the version field - so
+  this corrects a version string, not behaviour.
+
 ## [0.10.0] - 2026-08-20
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "mux-lang"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1221,8 +1221,8 @@ dependencies = [
 
 [[package]]
 name = "mux-runtime"
-version = "0.5.0"
-source = "git+https://github.com/muxlang/mux-runtime?branch=main#34361576241ad44f48f1cb799aa77bbc1952b2b0"
+version = "0.6.0"
+source = "git+https://github.com/muxlang/mux-runtime?branch=main#d4325f416bee905bbc0d37af023b443c115d2a34"
 dependencies = [
  "chrono",
  "csv",

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **The Programming Language For Everyone**
 
-[![Version](https://img.shields.io/badge/version-0.10.0-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
+[![Version](https://img.shields.io/badge/version-0.10.1-blue.svg?style=flat-square)](https://github.com/muxlang/mux-compiler/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-blue.svg?style=flat-square)](https://mux-lang.dev)
 [![Status](https://img.shields.io/badge/status-alpha-orange.svg?style=flat-square)]()
@@ -199,7 +199,7 @@ Profiling is done with external tools so it stays decoupled from the compiler an
 
 ⚠️ **Alpha Stage**: Mux is actively being developed. Expect breaking changes and incomplete features as we work toward a stable release.
 
-- **Current Version:** 0.10.0
+- **Current Version:** 0.10.1
 
 ## Versioning
 

--- a/mux-compiler/Cargo.toml
+++ b/mux-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mux-lang"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 default-run = "mux"
 description = "The Mux Programming Language Compiler"


### PR DESCRIPTION
`v0.10.0` pinned `3436157` - the commit *before* mux-runtime closed its changelog at 0.6.0 (muxlang/mux-runtime#62). So the binary reports:

```
runtime v0.5.0+g3436157   what v0.10.0 says
runtime v0.6.0+gd4325f4   what it actually is
```

**The pinned code is identical.** That runtime commit changed only docs and the version field, so 0.10.0 is functionally correct - this corrects a version string, not behaviour.

A tag cannot be moved, so the correction is a patch release rather than an amendment. Worth one: a release whose stated theme is that versions should not drift is a poor place to leave a version drifting.

## Verification

```
compiler v0.10.1
runtime  v0.6.0+gd4325f4
```

All five feature scripts pass against the new pin, with `MUX_RUNTIME_LIB` unset.

## Note on the ordering knot this sits next to

mux-runtime `main` is currently red, and not because of this: its Downstream Compiler Smoke Test runs mux-examples from `main`, which still uses `some`/`none`. On a push there is no PR label, so `paired-examples` cannot help. It clears when muxlang/mux-examples#5 merges - which needed the 0.10.0 release to exist so its own CI could compile the new spelling.