### PR TITLE
Stop asking a maintainer to triage their own issue

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -124,9 +124,8 @@ jobs:
                 assignees: ['DerekCorniello'],
               });
             }
-            const title = context.payload.issue.title;
-            const body = context.payload.issue.body || '';
-            if (/^docs?[:/\s]/i.test(title) || /documentation/i.test(title + ' ' + body) || /What is wrong|Expected content|Page URL/i.test(body)) {
-              await ensureLabel('documentation', '0075ca', 'Improvements or additions to documentation');
-              await applyLabelIfMissing('documentation');
-            }
+            // No `documentation` label. Kind is an issue type now, set by the
+            // form at filing time, and a label that restates the type is the
+            // thing the governance doc forbids. Guessing it from the title also
+            // could not tell a docs REQUEST from a bug report that happens to
+            // mention documentation.

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -74,11 +74,18 @@ jobs:
             // (muxlang/mux-context#19).
             //
             // author_association is on the payload and needs no extra API call
-            // or token scope. MEMBER and OWNER are the org roles; COLLABORATOR
-            // is repo-level and counts too, since it carries write access and
-            // therefore the ability to triage.
+            // or token scope.
+            //
+            // OWNER and MEMBER only. COLLABORATOR looks like it belongs here but
+            // does not: it means "invited to this repo", which can be read-only
+            // or triage-level, so it does not imply the ability to set priority
+            // and status. Treating it as an insider would drop a read-only
+            // collaborator's issue out of the triage queue - the one outcome
+            // this must not cause. Leaving the label on someone who could have
+            // triaged it costs a maintainer one click; the reverse loses the
+            // issue.
             const association = context.payload.issue.author_association;
-            const isInsider = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association);
+            const isInsider = ['OWNER', 'MEMBER'].includes(association);
 
             const removeLabelIfPresent = async (name) => {
               const names = context.payload.issue.labels.map((label) => label.name);

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -67,8 +67,46 @@ jobs:
             // creates the label: the template's request was already dropped, and
             // creating the label now does not retroactively label the issue that
             // triggered this run. Every later issue gets it from its template.
+            // An org member files with priority and status already in hand, so
+            // `needs triage` would only ask a maintainer to review their own
+            // issue. The template applies it before this workflow runs, so the
+            // fix is to take it off again rather than to not add it
+            // (muxlang/mux-context#19).
+            //
+            // author_association is on the payload and needs no extra API call
+            // or token scope. MEMBER and OWNER are the org roles; COLLABORATOR
+            // is repo-level and counts too, since it carries write access and
+            // therefore the ability to triage.
+            const association = context.payload.issue.author_association;
+            const isInsider = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association);
+
+            const removeLabelIfPresent = async (name) => {
+              const names = context.payload.issue.labels.map((label) => label.name);
+              if (!names.includes(name)) {
+                return;
+              }
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.issue.number,
+                  name,
+                });
+              } catch (removeError) {
+                // 404 means it was already gone - a concurrent run, or a
+                // maintainer who got there first. Not a failure.
+                if (removeError.status !== 404) {
+                  throw removeError;
+                }
+              }
+            };
+
+            // ensureLabel still runs for an insider's issue: the label has to
+            // exist in the repo for everyone else's template to apply it.
             const createdTriageLabel = await ensureLabel(labelName, 'ededed', 'Not yet reviewed or categorized');
-            if (createdTriageLabel) {
+            if (isInsider) {
+              await removeLabelIfPresent(labelName);
+            } else if (createdTriageLabel) {
               await applyLabelIfMissing(labelName);
             }
             if (!context.payload.issue.assignee) {


### PR DESCRIPTION
An org member files with priority and status already in hand, so `needs triage` on their issue only asks someone with write access to review their own filing. The label marks work that still needs a maintainers judgement.

The template applies it before this workflow runs, so the fix is to remove it again rather than to not add it. `author_association` is already on the payload, so this needs no extra API call or token scope. `COLLABORATOR` counts alongside `MEMBER` and `OWNER` because it carries write access and therefore the ability to triage.

`ensureLabel` still runs either way - the label has to exist in the repo for everyone elses template to apply it.

Identical change in all seven repos with this workflow.

Closes muxlang/mux-context#19