### PR TITLE
Sync issue templates: record the kind as an issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report incorrect compiler behavior or a crash
 labels: ["needs triage"]
+type: Bug
 assignees: ["DerekCorniello"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation_fix.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_fix.yml
@@ -1,6 +1,7 @@
 name: Documentation fix
 description: Report incorrect or missing compiler documentation
-labels: ["needs triage"]
+labels: ["documentation", "needs triage"]
+type: Documentation
 assignees: ["DerekCorniello"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature request
 description: Suggest a new language or compiler capability
 labels: ["needs triage"]
+type: Enhancement
 assignees: ["DerekCorniello"]
 body:
   - type: textarea


### PR DESCRIPTION
Every form now sets an issue type - Bug, Enhancement, Documentation, Chore or Decision - so kind is a first-class field rather than something inferred from which form was used and then re-encoded as a label during triage.

The org types were created and all open issues backfilled; see muxlang/.github#8 for the source change and the full mapping.

Synced from `muxlang/.github/templates`, not hand-edited.

Part of muxlang/mux-context#19